### PR TITLE
build: fix issues that prevent building locally

### DIFF
--- a/src/migrations/1643714286947_tokens.sql
+++ b/src/migrations/1643714286947_tokens.sql
@@ -1,5 +1,5 @@
 -- Up Migration
-
+CREATE EXTENSION hstore;
 CREATE TABLE "tokens" (
   "contract" BYTEA NOT NULL,
   "token_id" NUMERIC(78, 0) NOT NULL,

--- a/src/migrations/1645976283000_daily-volumes.sql
+++ b/src/migrations/1645976283000_daily-volumes.sql
@@ -35,9 +35,6 @@ ALTER TABLE "collections"
 ALTER TABLE "collections"
   ADD "all_time_rank" INT;
 
-CREATE INDEX "fill_events_2_timestamp_index"
-  ON "fill_events_2" ("timestamp");
-
 CREATE INDEX "collections_day1_volume_index"
   ON "collections" ("day1_volume" DESC);
 


### PR DESCRIPTION
I tried to build and run the indexer locally and hit two issues. I found what they were and fixed them in this PR. Now, `docker-compose up` and `yarn build && yarn start` works on my machine.

1. Got an issue because hstore didn't exist, so I added it to the only sql file that i saw that used it.
2. Then I got a duplicate relation error for an index. I saw it was listed in two places so I got rid of one of them.

Don't feel strongly about landing this; putting up in case helpful.