### PR TITLE
fix: removed redundant sort

### DIFF
--- a/src/api/endpoints/tokens/get-user-tokens/v2.ts
+++ b/src/api/endpoints/tokens/get-user-tokens/v2.ts
@@ -126,7 +126,6 @@ export const getUserTokensV2Options: RouteOptions = {
             WHERE b.token_id = t.token_id
             AND b.contract = t.contract
             ${collectionFilter}
-            ORDER BY t.top_buy_value DESC NULLS LAST
           ) t ON TRUE
           JOIN collections c ON c.id = t.collection_id
           ${communityFilter}


### PR DESCRIPTION
removed sort by top bid as it was redundant inside the join and was causing the request to timeout when including a collection in the query 