### PR TITLE
Feat/add created at fill events

### DIFF
--- a/src/jobs/backfill/backfill-fill-events-created-at.ts
+++ b/src/jobs/backfill/backfill-fill-events-created-at.ts
@@ -65,7 +65,7 @@ if (config.doBackgroundWork) {
   redlock
     .acquire([`${QUEUE_NAME}-lock`], 60 * 60 * 24 * 30 * 1000)
     .then(async () => {
-      // await addToQueue();
+      await addToQueue();
     })
     .catch(() => {
       // Skip on any errors

--- a/src/jobs/backfill/backfill-fill-events-created-at.ts
+++ b/src/jobs/backfill/backfill-fill-events-created-at.ts
@@ -65,7 +65,7 @@ if (config.doBackgroundWork) {
   redlock
     .acquire([`${QUEUE_NAME}-lock`], 60 * 60 * 24 * 30 * 1000)
     .then(async () => {
-      await addToQueue();
+      // await addToQueue();
     })
     .catch(() => {
       // Skip on any errors

--- a/src/jobs/backfill/backfill-fill-events-created-at.ts
+++ b/src/jobs/backfill/backfill-fill-events-created-at.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Queue, QueueScheduler, Worker } from "bullmq";
+import { randomUUID } from "crypto";
+
+import { logger } from "@/common/logger";
+import { redis, redlock } from "@/common/redis";
+import { config } from "@/config/index";
+
+import { idb } from "@/common/db";
+
+const QUEUE_NAME = "backfill-fill-events-created-at-queue";
+
+export const queue = new Queue(QUEUE_NAME, {
+  connection: redis.duplicate(),
+  defaultJobOptions: {
+    attempts: 10,
+    removeOnComplete: 10000,
+    removeOnFail: 10000,
+  },
+});
+new QueueScheduler(QUEUE_NAME, { connection: redis.duplicate() });
+
+// BACKGROUND WORKER ONLY
+if (config.doBackgroundWork) {
+  const worker = new Worker(
+    QUEUE_NAME,
+    async () => {
+      const limit = 500;
+
+      const { rowCount } = await idb.result(
+        `
+            WITH x AS (
+                SELECT "timestamp", log_index, batch_index 
+                FROM fill_events_2
+                WHERE created_at IS NULL
+                LIMIT $/limit/
+            )
+            UPDATE fill_events_2 SET
+              created_at = to_timestamp(x."timestamp")
+            FROM x
+            WHERE fill_events_2."timestamp" = x."timestamp"
+            AND fill_events_2.log_index = x.log_index
+            AND fill_events_2.batch_index = x.batch_index
+          `,
+        {
+          limit,
+        }
+      );
+
+      logger.info(QUEUE_NAME, `Updated ${rowCount} records`);
+
+      if (rowCount > 0) {
+        logger.info(QUEUE_NAME, `Triggering next job.`);
+        await addToQueue();
+      }
+    },
+    { connection: redis.duplicate(), concurrency: 1 }
+  );
+
+  worker.on("error", (error) => {
+    logger.error(QUEUE_NAME, `Worker errored: ${error}`);
+  });
+
+  redlock
+    .acquire([`${QUEUE_NAME}-lock`], 60 * 60 * 24 * 30 * 1000)
+    .then(async () => {
+      // await addToQueue();
+    })
+    .catch(() => {
+      // Skip on any errors
+    });
+}
+
+export const addToQueue = async () => {
+  await queue.add(
+    randomUUID(),
+    {},
+    {
+      delay: 1000,
+    }
+  );
+};

--- a/src/jobs/backfill/index.ts
+++ b/src/jobs/backfill/index.ts
@@ -1,1 +1,2 @@
 import "@/jobs/backfill/token-floor-ask-events";
+import "@/jobs/backfill/backfill-fill-events-created-at";

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -59,6 +59,7 @@ import * as removeUnsyncedEventsActivities from "@/jobs/activities/remove-unsync
 import * as fixActivitiesMissingCollection from "@/jobs/activities/fix-activities-missing-collection";
 import * as updateNftBalanceTopBidQueue from "@/jobs/nft-balance-updates/update-top-bid-queue";
 import * as backfillNftBalanceTopBidQueue from "@/jobs/nft-balance-updates/backfill-top-bid-queue";
+import * as backfillFillEventsCreatedAt from "@/jobs/backfill/backfill-fill-events-created-at";
 
 export const allJobQueues = [
   arweaveSyncBackfill.queue,
@@ -101,4 +102,5 @@ export const allJobQueues = [
   fixActivitiesMissingCollection.queue,
   updateNftBalanceTopBidQueue.queue,
   backfillNftBalanceTopBidQueue.queue,
+  backfillFillEventsCreatedAt.queue,
 ];

--- a/src/migrations/1644930748093_fills.sql
+++ b/src/migrations/1644930748093_fills.sql
@@ -24,7 +24,8 @@ CREATE TABLE "fill_events_2" (
   "contract" BYTEA NOT NULL,
   "token_id" NUMERIC(78, 0) NOT NULL,
   "amount" NUMERIC(78, 0) NOT NULL,
-  "fill_source" fill_source_t
+  "fill_source" fill_source_t,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 ALTER TABLE "fill_events_2"


### PR DESCRIPTION
Adding `create_at` column will happen in 2 steps:
```
ALTER TABLE fill_events_2
ADD COLUMN created_at TIMESTAMPTZ;

ALTER TABLE fill_events_2
ALTER COLUMN created_at SET DEFAULT now();
```

Then, run a backfill:
```
CREATE INDEX CONCURRENTLY "fill_events_2_created_at_null_update_index"
  ON "fill_events_2" ("created_at")
  INCLUDE ("timestamp", "log_index", "batch_index")
    WHERE ("created_at" is NULL)
```

Then update `created_at` to be non null:
```
ALTER TABLE fill_events_2
ALTER COLUMN created_at SET NOT NULL;
```