### PR TITLE
feat(collections): filter sample_images when null

### DIFF
--- a/src/api/endpoints/collections/get-collection/v2.ts
+++ b/src/api/endpoints/collections/get-collection/v2.ts
@@ -166,6 +166,7 @@ export const getCollectionV2Options: RouteOptions = {
           ARRAY(
             SELECT "t"."image" FROM "tokens" "t"
             WHERE "t"."collection_id" = "c"."id"
+            AND "t"."image" IS NOT NULL
             LIMIT 4
           ) AS "sample_images"          
         FROM "collections" "c"

--- a/src/api/endpoints/collections/get-collections/v4.ts
+++ b/src/api/endpoints/collections/get-collections/v4.ts
@@ -138,6 +138,7 @@ export const getCollectionsV4Options: RouteOptions = {
             SELECT array(
               SELECT tokens.image FROM tokens
               WHERE tokens.collection_id = collections.id
+              AND tokens.image IS NOT NULL
               LIMIT 4
             )
           ) AS sample_images,

--- a/src/api/endpoints/collections/get-user-collections/v2.ts
+++ b/src/api/endpoints/collections/get-user-collections/v2.ts
@@ -129,6 +129,7 @@ export const getUserCollectionsV2Options: RouteOptions = {
                   SELECT array(
                     SELECT tokens.image FROM tokens
                     WHERE tokens.collection_id = collections.id
+                    AND tokens.image IS NOT NULL
                     LIMIT 4
                   )
                 ) AS sample_images,

--- a/src/api/endpoints/stats/get-stats/v1.ts
+++ b/src/api/endpoints/stats/get-stats/v1.ts
@@ -293,6 +293,7 @@ export const getStatsV1Options: RouteOptions = {
             array(
               SELECT "t"."image" FROM "tokens" "t"
               WHERE "t"."collection_id" = $/collection/
+              AND "t"."image" IS NOT NULL
               LIMIT 4
             ) AS "sample_images",
             "x".*,


### PR DESCRIPTION
A while ago I noticed some blank images show up in in preview cards for a communities marketplace.

The underlying issue was that some sample_images were null -- eg `[image1, null, null, image4]`. 

the issue that caused the nulls was that reservoir was getting rate-limited.

feels like the sample_images can be anything from the collection (eg doesnt need to be any particular 4 images), so this diff just filters out nulls.

note that i only did this for endpoints that were not tagged as x-deprecated.

orig discussion identifying the nulls at
https://discord.com/channels/872790973309153280/926358989770473493/987074452594499644