### PR TITLE
Fix Universe order creating + filling logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@hapi/inert": "^6.0.4",
     "@hapi/vision": "^6.1.0",
     "@poprank/rankings": "^1.1.20",
-    "@reservoir0x/sdk": "0.0.183",
+    "@reservoir0x/sdk": "0.0.184",
     "@types/date-fns": "^2.6.0",
     "@types/hapi__basic": "^5.1.2",
     "@types/hapi__hapi": "^20.0.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@hapi/inert": "^6.0.4",
     "@hapi/vision": "^6.1.0",
     "@poprank/rankings": "^1.1.20",
-    "@reservoir0x/sdk": "0.0.184",
+    "@reservoir0x/sdk": "0.0.185",
     "@types/date-fns": "^2.6.0",
     "@types/hapi__basic": "^5.1.2",
     "@types/hapi__hapi": "^20.0.9",

--- a/src/api/endpoints/orders/post-order/v3.ts
+++ b/src/api/endpoints/orders/post-order/v3.ts
@@ -31,13 +31,13 @@ export const postOrderV3Options: RouteOptions = {
       order: Joi.object({
         kind: Joi.string()
           .lowercase()
-          .valid("opensea", "looks-rare", "zeroex-v4", "seaport", "x2y2")
+          .valid("opensea", "looks-rare", "zeroex-v4", "seaport", "x2y2", "universe")
           .required(),
         data: Joi.object().required(),
       }),
       orderbook: Joi.string()
         .lowercase()
-        .valid("reservoir", "opensea", "looks-rare", "x2y2")
+        .valid("reservoir", "opensea", "looks-rare", "x2y2", "universe")
         .default("reservoir"),
       orderbookApiKey: Joi.string(),
       source: Joi.string()
@@ -263,6 +263,28 @@ export const postOrderV3Options: RouteOptions = {
           );
 
           return { message: "Success" };
+        }
+
+        case "universe": {
+          if (!["universe"].includes(orderbook)) {
+            throw new Error("Unknown orderbook");
+          }
+
+          const orderInfo: orders.universe.OrderInfo = {
+            orderParams: order.data,
+            metadata: {
+              schema,
+              source: orderbook === "universe" ? source : undefined,
+            },
+          };
+
+          const [result] = await orders.universe.save([orderInfo]);
+
+          if (result.status !== "success") {
+            throw Boom.badRequest(result.status);
+          }
+
+          return { message: "Success", orderId: result.id };
         }
       }
 

--- a/src/orderbook/orders/universe/build/utils.ts
+++ b/src/orderbook/orders/universe/build/utils.ts
@@ -2,7 +2,6 @@ import * as Sdk from "@reservoir0x/sdk";
 
 import { redb } from "@/common/db";
 import { OrderSide } from "@reservoir0x/sdk/dist/universe/types";
-import { toBuffer } from "@/common/utils";
 
 export interface BaseOrderBuildOptions {
   maker: string;
@@ -50,16 +49,6 @@ export const getBuildInfo = async (
     throw new Error("Invalid NFT asset class");
   }
 
-  const makerOrdersCount = await redb.many(
-    `
-    SELECT
-      COUNT(orders.maker)
-    FROM orders
-    WHERE orders.maker = $/maker/
-  `,
-    { maker: toBuffer(options.maker) }
-  );
-
   const params: Sdk.Universe.Types.BaseBuildParams = {
     maker: options.maker,
     side: side === OrderSide.BUY ? "buy" : "sell",
@@ -70,10 +59,8 @@ export const getBuildInfo = async (
     price: options.weiPrice,
     paymentToken: options.currency,
     fees: options.fees,
-    salt: Number(makerOrdersCount[0].count ?? 0) + 1,
     startTime: options.listingTime,
     endTime: options.expirationTime,
-    signature: "",
   };
   return {
     params,

--- a/src/orderbook/orders/universe/index.ts
+++ b/src/orderbook/orders/universe/index.ts
@@ -118,17 +118,7 @@ export const save = async (
           break;
         // Sell order
         case "sell":
-          if (
-            (order.params.take.assetType.assetClass === "ERC20" &&
-              currency !== Sdk.Common.Addresses.Weth[config.chainId]) ||
-            order.params.take.assetType.assetClass !== "ETH"
-          ) {
-            return results.push({
-              id,
-              status: "unsupported-payment-token",
-            });
-          }
-
+          // We allow ETH and ERC20 orders so no need to validate here
           break;
         default:
           return results.push({

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -149,9 +149,7 @@ export const syncEvents = async (
 
         // TODO: Remove
         switch (eventData?.kind) {
-          // Rarible / Universe
-
-          case "universe-match":
+          // Rarible
           case "rarible-match": {
             const { args } = eventData.abi.parseLog(log);
             const leftHash = args["leftHash"].toLowerCase();
@@ -365,6 +363,10 @@ export const syncEvents = async (
       {
         kind: "zora",
         events: enhancedEvents.filter(({ kind }) => kind.startsWith("zora")),
+      },
+      {
+        kind: "universe",
+        events: enhancedEvents.filter(({ kind }) => kind.startsWith("universe")),
       },
     ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,10 +1573,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@reservoir0x/sdk@0.0.183":
-  version "0.0.183"
-  resolved "https://registry.yarnpkg.com/@reservoir0x/sdk/-/sdk-0.0.183.tgz#a61a974add96d565846b484fdbeddb657b7b7b23"
-  integrity sha512-QxbZHn5OBHk3r4ivqIX/PU8ZqJejmRj9iDcKzkjx6XI/hUEqZ1A/a5lhlzX/X+he9FsAW0CatRetdjADzx7rGA==
+"@reservoir0x/sdk@0.0.184":
+  version "0.0.184"
+  resolved "https://registry.yarnpkg.com/@reservoir0x/sdk/-/sdk-0.0.184.tgz#9ef36f8746957c25b1376bb38af14bd8b7f94c82"
+  integrity sha512-47d1DbXsYg+/JAHQhDngFQP6Qw2ulXU1B4uLNl3FxfQxJzrO8TuL2+REfARCNUznFFa1IZ+F6/+xOEWIZMRDDw==
   dependencies:
     ethers "^5.6.8"
     merkletreejs "0.2.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,10 +1573,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@reservoir0x/sdk@0.0.184":
-  version "0.0.184"
-  resolved "https://registry.yarnpkg.com/@reservoir0x/sdk/-/sdk-0.0.184.tgz#9ef36f8746957c25b1376bb38af14bd8b7f94c82"
-  integrity sha512-47d1DbXsYg+/JAHQhDngFQP6Qw2ulXU1B4uLNl3FxfQxJzrO8TuL2+REfARCNUznFFa1IZ+F6/+xOEWIZMRDDw==
+"@reservoir0x/sdk@0.0.185":
+  version "0.0.185"
+  resolved "https://registry.yarnpkg.com/@reservoir0x/sdk/-/sdk-0.0.185.tgz#137c04ee4f349e6da90c0cf0328518acba9c65de"
+  integrity sha512-0JHF9dvU92/l5bE9kB2hqxhonEJaHwbskA1PgrkEfBZ/dps7/ZIr5gKo7tQtzN7T6COBAXLelRfETdnaGuB97w==
   dependencies:
     ethers "^5.6.8"
     merkletreejs "0.2.31"


### PR DESCRIPTION
Changes:
1. Various validation + execution logic issues that I encountered during creating and filling sell orders from our FE dev environment.
2. Added missing logic inside `post-order/v3.ts`.
3. Salt calculation that's based on the amount of orders the user has created. This ensures that hashOrderKey() will always return a different hash even if all other order parameters are the same

To be added:
1. SDK package version to be `0.0.184` after https://github.com/reservoirprotocol/core/pull/36 is merged