### PR TITLE
feat: universe - fix 1155 filling

### DIFF
--- a/src/orderbook/orders/index.ts
+++ b/src/orderbook/orders/index.ts
@@ -293,6 +293,9 @@ export const generateBidDetails = async (
         kind: "universe",
         ...common,
         order: sdkOrder,
+        extraArgs: {
+          amount: sdkOrder.params.take.value,
+        },
       };
     }
 


### PR DESCRIPTION
We have to pass amount to sdk in order to be able to build 1155 orders