### PR TITLE
fix: tokens with null metadata are still returned, so continuation ca…

### DIFF
--- a/src/api/endpoints/transfers/get-sales/v4.ts
+++ b/src/api/endpoints/transfers/get-sales/v4.ts
@@ -273,7 +273,7 @@ export const getSalesV4Options: RouteOptions = {
         ${
           query.includeTokenMetadata
             ? `
-                JOIN LATERAL (
+                LEFT JOIN LATERAL (
                   SELECT
                     tokens.name,
                     tokens.image,


### PR DESCRIPTION
…n be set

issue describing reason for null metadata: https://linear.app/reservoir/issue/RES-1019/shared-storefront-tokens-contract-mixup