### PR TITLE
fix: null metadata tokens are returned, so continuation can be set

### DIFF
--- a/src/api/endpoints/transfers/get-sales/v4.ts
+++ b/src/api/endpoints/transfers/get-sales/v4.ts
@@ -273,7 +273,7 @@ export const getSalesV4Options: RouteOptions = {
         ${
           query.includeTokenMetadata
             ? `
-                JOIN LATERAL (
+                LEFT JOIN LATERAL (
                   SELECT
                     tokens.name,
                     tokens.image,


### PR DESCRIPTION
issue describing reason for null metadata: https://linear.app/reservoir/issue/RES-1019/shared-storefront-tokens-contract-mixup