### PR TITLE
perf: move collectionsSetId filter into JOIN

### DIFF
--- a/src/models/activities/index.ts
+++ b/src/models/activities/index.ts
@@ -263,8 +263,7 @@ export class Activities {
 
     if (collectionsSetId) {
       joinCollectionsSet =
-        "JOIN collections_sets_collections csc ON activities.collection_id = csc.collection_id";
-      collectionFilter = "WHERE csc.collections_set_id = $/collectionsSetId/";
+        "JOIN collections_sets_collections csc ON activities.collection_id = csc.collection_id AND csc.collections_set_id = $/collectionsSetId/";
     } else if (community) {
       collectionFilter =
         "WHERE collection_id IN (SELECT id FROM collections WHERE community = $/community/)";


### PR DESCRIPTION
I get consistent 504 errors when I try to use a collectionsSetId as input to the getcollectionsactivityv4 endpoint, even if there are only two collections in the set (eg `dc5a32d9dcc64f67dea776bb43cb7a4932cc5e52dce8e1b7edad0f56a9cec2c8`) and not including metadata.

I noticed the entire activities table gets joined against the entire collections_sets_collections table, and only later filtered down to the queried collectionsSetId.

This diff moves that filter into the JOIN ON statement. I'm not super familiar with SQL performance but maybe this will help