### PR TITLE
Rarible - add collection bids support

### DIFF
--- a/src/api/endpoints/execute/get-execute-sell/v5.ts
+++ b/src/api/endpoints/execute/get-execute-sell/v5.ts
@@ -257,7 +257,7 @@ export const getExecuteSellV5Options: RouteOptions = {
         },
       ];
 
-      // X2Y2 / Sudoswap / Forward bids are to be filled directly (because we have no modules for them yet)
+      // X2Y2 / Sudoswap / Forward/ Rarible bids are to be filled directly (because we have no modules for them yet)
       if (bidDetails.kind === "x2y2") {
         const isApproved = await getNftApproval(
           bidDetails.contract,
@@ -331,6 +331,42 @@ export const getExecuteSellV5Options: RouteOptions = {
                   baseProvider,
                   bidDetails.contract
                 ).approveTransaction(payload.taker, Sdk.Forward.Addresses.Exchange[config.chainId]);
+
+          steps[0].items.push({
+            status: "incomplete",
+            data: {
+              ...approveTx,
+              maxFeePerGas: payload.maxFeePerGas
+                ? bn(payload.maxFeePerGas).toHexString()
+                : undefined,
+              maxPriorityFeePerGas: payload.maxPriorityFeePerGas
+                ? bn(payload.maxPriorityFeePerGas).toHexString()
+                : undefined,
+            },
+          });
+        }
+      }
+      if (bidDetails.kind === "rarible") {
+        const isApproved = await getNftApproval(
+          bidDetails.contract,
+          payload.taker,
+          Sdk.Rarible.Addresses.NFTTransferProxy[config.chainId]
+        );
+
+        if (!isApproved) {
+          const approveTx =
+            bidDetails.contractKind === "erc721"
+              ? new Sdk.Common.Helpers.Erc721(baseProvider, bidDetails.contract).approveTransaction(
+                  payload.taker,
+                  Sdk.Rarible.Addresses.NFTTransferProxy[config.chainId]
+                )
+              : new Sdk.Common.Helpers.Erc1155(
+                  baseProvider,
+                  bidDetails.contract
+                ).approveTransaction(
+                  payload.taker,
+                  Sdk.Rarible.Addresses.NFTTransferProxy[config.chainId]
+                );
 
           steps[0].items.push({
             status: "incomplete",

--- a/src/api/endpoints/execute/get-execute-sell/v6.ts
+++ b/src/api/endpoints/execute/get-execute-sell/v6.ts
@@ -300,7 +300,7 @@ export const getExecuteSellV6Options: RouteOptions = {
         },
       ];
 
-      // X2Y2 / Sudoswap / Forward bids are to be filled directly (because we have no modules for them yet)
+      // X2Y2 / Sudoswap / Forward / Rarible bids are to be filled directly (because we have no modules for them yet)
       if (bidDetails.kind === "x2y2") {
         const isApproved = await getNftApproval(
           bidDetails.contract,
@@ -374,6 +374,43 @@ export const getExecuteSellV6Options: RouteOptions = {
                   baseProvider,
                   bidDetails.contract
                 ).approveTransaction(payload.taker, Sdk.Forward.Addresses.Exchange[config.chainId]);
+
+          steps[0].items.push({
+            status: "incomplete",
+            data: {
+              ...approveTx,
+              maxFeePerGas: payload.maxFeePerGas
+                ? bn(payload.maxFeePerGas).toHexString()
+                : undefined,
+              maxPriorityFeePerGas: payload.maxPriorityFeePerGas
+                ? bn(payload.maxPriorityFeePerGas).toHexString()
+                : undefined,
+            },
+          });
+        }
+      }
+
+      if (bidDetails.kind === "rarible") {
+        const isApproved = await getNftApproval(
+          bidDetails.contract,
+          payload.taker,
+          Sdk.Rarible.Addresses.NFTTransferProxy[config.chainId]
+        );
+
+        if (!isApproved) {
+          const approveTx =
+            bidDetails.contractKind === "erc721"
+              ? new Sdk.Common.Helpers.Erc721(baseProvider, bidDetails.contract).approveTransaction(
+                  payload.taker,
+                  Sdk.Rarible.Addresses.NFTTransferProxy[config.chainId]
+                )
+              : new Sdk.Common.Helpers.Erc1155(
+                  baseProvider,
+                  bidDetails.contract
+                ).approveTransaction(
+                  payload.taker,
+                  Sdk.Rarible.Addresses.NFTTransferProxy[config.chainId]
+                );
 
           steps[0].items.push({
             status: "incomplete",

--- a/src/orderbook/orders/rarible/index.ts
+++ b/src/orderbook/orders/rarible/index.ts
@@ -200,7 +200,17 @@ export const save = async (
               tokenId: tokenId,
             },
           ]);
+          break;
+        }
 
+        case "contract-wide": {
+          [{ id: tokenSetId }] = await tokenSet.contractWide.save([
+            {
+              id: `contract:${collection}`,
+              schemaHash,
+              contract: collection,
+            },
+          ]);
           break;
         }
       }


### PR DESCRIPTION
I've added token approval logic to get-execute sell v6 and v5 because during testing the FE Reservoir kit hit v5 endpoint. I don't think it will hurt to be added to both places