### PR TITLE
feat: improve loading time of v5/tokens with source

### DIFF
--- a/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -356,61 +356,57 @@ export const getTokensV5Options: RouteOptions = {
       (query as any).source = source?.id;
       selectFloorData = "s.*";
 
-      if (query.normalizeRoyalties) {
-        sourceQuery = `
-          JOIN LATERAL (
-            SELECT o.id AS floor_sell_id,
+      const sourceConditions: string[] = [];
+      sourceConditions.push(`o.side = 'sell'`);
+      sourceConditions.push(`o.fillability_status = 'fillable'`);
+      sourceConditions.push(`o.approval_status = 'approved'`);
+      sourceConditions.push(`o.source_id_int = $/source/`);
+
+      if (query.contract) {
+        sourceConditions.push(`tst.contract = $/contract/`);
+      } else if (query.collection) {
+        let contractString = query.collection;
+        if (query.collection.includes(":")) {
+          const [contract, ,] = query.collection.split(":");
+          contractString = contract;
+        }
+
+        (query as any).contract = _.replace(contractString, "0x", "\\x");
+        sourceConditions.push(`tst.contract = $/contract/`);
+      }
+
+      sourceQuery = `
+        JOIN LATERAL (
+          SELECT
+                  DISTINCT ON (token_id, contract)
+                  tst.token_id AS token_id,
+                  tst.contract AS contract,
+                  o.id AS floor_sell_id,
                   o.maker AS floor_sell_maker,
                   o.id AS source_floor_sell_id,
                   date_part('epoch', lower(o.valid_between)) AS floor_sell_valid_from,
                   coalesce(
-                      nullif(date_part('epoch', upper(o.valid_between)), 'Infinity'),
-                      0
+                    nullif(date_part('epoch', upper(o.valid_between)), 'Infinity'),
+                    0
                   ) AS floor_sell_valid_to,
                   o.source_id_int AS floor_sell_source_id_int,
-                  o.normalized_value AS floor_sell_value,
+                  ${
+                    query.normalizeRoyalties ? "o.normalized_value" : "o.value"
+                  } AS floor_sell_value,
                   o.currency AS floor_sell_currency,
                   o.currency_normalized_value AS floor_sell_currency_value
-            FROM orders o
-            JOIN token_sets_tokens tst ON o.token_set_id = tst.token_set_id
-            WHERE tst.contract = t.contract
-            AND tst.token_id = t.token_id
-            AND o.side = 'sell'
-            AND o.fillability_status = 'fillable'
-            AND o.approval_status = 'approved'
-            AND o.source_id_int = $/source/
-            ORDER BY o.normalized_value, o.value
-            LIMIT 1
-          ) s ON TRUE
-        `;
-      } else {
-        sourceQuery = `
-          JOIN LATERAL (
-            SELECT o.id AS floor_sell_id,
-                  o.maker AS floor_sell_maker,
-                  o.id AS source_floor_sell_id,
-                  date_part('epoch', lower(o.valid_between)) AS floor_sell_valid_from,
-                  coalesce(
-                      nullif(date_part('epoch', upper(o.valid_between)), 'Infinity'),
-                      0
-                  ) AS floor_sell_valid_to,
-                  o.source_id_int AS floor_sell_source_id_int,
-                  o.value AS floor_sell_value,
-                  o.currency AS floor_sell_currency,
-                  o.currency_value AS floor_sell_currency_value
-            FROM orders o
-            JOIN token_sets_tokens tst ON o.token_set_id = tst.token_set_id
-            WHERE tst.contract = t.contract
-            AND tst.token_id = t.token_id
-            AND o.side = 'sell'
-            AND o.fillability_status = 'fillable'
-            AND o.approval_status = 'approved'
-            AND o.source_id_int = $/source/
-            ORDER BY o.value
-            LIMIT 1
-          ) s ON TRUE
-        `;
-      }
+          FROM orders o
+          JOIN token_sets_tokens tst ON o.token_set_id = tst.token_set_id
+          ${
+            sourceConditions.length
+              ? " WHERE " + sourceConditions.map((c) => `(${c})`).join(" AND ")
+              : ""
+          }
+          ORDER BY token_id, contract, ${
+            query.normalizeRoyalties ? "o.normalized_value" : "o.value"
+          }
+        ) s ON s.contract = t.contract AND s.token_id = t.token_id      
+      `;
     }
 
     try {


### PR DESCRIPTION
## Problem
When `source` is passed in to `v5/tokens`, we return the token floor prices per token.  This leads to a more intensive query as we need to reference the `orders` table + filter on `source` in order to find the floor price by source.

## Solution
Remove expensive nested loop join query so it only needs to be run once instead of O(n), where n = # of tokens. 

See the highlighted portions below for the critical changes made

## Query
```
http://localhost:3000/tokens/v5?collection=0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e&limit=20&sortBy=floorAskPrice&source=marketplace.truthlabs.co
```

## Before
Lateral join on `tst.contract = t.contract AND tst.token_id = t.token_id` means the database needs to run this join PER ROW, which is super expensive.

```
EXPLAIN ANALYZE SELECT
  t.*, s.*
FROM tokens t
JOIN LATERAL (
  SELECT o.value AS floor_sell_value
  FROM orders o
  JOIN token_sets_tokens tst ON o.token_set_id = tst.token_set_id
  WHERE
    tst.contract = t.contract AND tst.token_id = t.token_id AND o.side = 'sell' AND o.fillability_status = 'fillable' AND o.approval_status = 'approved' AND o.source_id_int = 1344
  ORDER BY o.value
  LIMIT 1
) s ON TRUE
WHERE
  (t.collection_id = '0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e')
ORDER BY
  s.floor_sell_value ASC NULLS LAST,
  t.token_id
LIMIT 20;
```

Note the many ` loops=9999`
```
 Limit  (cost=1057195.65..1057195.70 rows=20 width=1108) (actual time=28422.167..28422.183 rows=20 loops=1)
   ->  Sort  (cost=1057195.65..1057208.33 rows=5070 width=1108) (actual time=28422.166..28422.180 rows=20 loops=1)
         Sort Key: o.value, t.token_id
         Sort Method: quicksort  Memory: 78kB
         ->  Nested Loop  (cost=205.14..1057060.74 rows=5070 width=1108) (actual time=367.416..28421.936 rows=27 loops=1)
               ->  Index Scan using tokens_collection_id_normalized_floor_sell_value_token_id_index on tokens t  (cost=0.69..20387.27 rows=5070 width=1101) (actual time=0.034..452.505 rows=9999 loops=1)
                     Index Cond: (collection_id = '0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e'::text)
               ->  Limit  (cost=204.45..204.45 rows=1 width=7) (actual time=2.796..2.796 rows=0 loops=9999)
                     ->  Sort  (cost=204.45..204.45 rows=1 width=7) (actual time=2.793..2.793 rows=0 loops=9999)
                           Sort Key: o.value
                           Sort Method: quicksort  Memory: 25kB
                           ->  Nested Loop  (cost=1.38..204.44 rows=1 width=7) (actual time=2.784..2.787 rows=0 loops=9999)
                                 ->  Index Only Scan using token_sets_tokens_contract_token_id_index on token_sets_tokens tst  (cost=0.70..8.78 rows=4 width=108) (actual time=1.664..1.677 rows=34 loops=9999)
                                       Index Cond: ((contract = t.contract) AND (token_id = t.token_id))
                                       Heap Fetches: 0
                                 ->  Index Scan using orders_token_set_id_side_value_maker_index on orders o  (cost=0.68..48.90 rows=1 width=94) (actual time=0.031..0.031 rows=0 loops=341527)
                                       Index Cond: ((token_set_id = tst.token_set_id) AND (side = 'sell'::order_side_t))
                                       Filter: (source_id_int = 1344)
                                       Rows Removed by Filter: 0
 Planning Time: 21.859 ms
 Execution Time: 28422.269 ms
```

## After
In the following construction the intermediate join query only needs to be run once.

```
EXPLAIN ANALYZE SELECT
  t.*,
  s.*
FROM tokens t
JOIN LATERAL (
  SELECT
    DISTINCT ON (token_id, contract)
    tst.token_id AS token_id,
    tst.contract AS contract,
    o.value AS floor_sell_value
  FROM orders o
  JOIN token_sets_tokens tst ON o.token_set_id = tst.token_set_id
    WHERE (o.side = 'sell') AND (o.fillability_status = 'fillable') AND (o.approval_status = 'approved') AND (o.source_id_int = 1344) AND (tst.contract = '\xbce3781ae7ca1a5e050bd9c4c77369867ebc307e')
  ORDER BY token_id, contract, o.value
) s ON s.contract = t.contract AND s.token_id = t.token_id
WHERE
  (t.collection_id = '0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e') AND (t.contract = '\xbce3781ae7ca1a5e050bd9c4c77369867ebc307e')
ORDER BY
  s.floor_sell_value ASC NULLS LAST,
  t.token_id
LIMIT 20;
```

Notice now how `loops=95`, which is the # of orders in this source.
```
 Limit  (cost=319798.73..319798.73 rows=1 width=1138) (actual time=1595.709..1595.716 rows=20 loops=1)
   ->  Sort  (cost=319798.73..319798.73 rows=1 width=1138) (actual time=1595.708..1595.713 rows=20 loops=1)
         Sort Key: o.value, t.token_id
         Sort Method: quicksort  Memory: 78kB
         ->  Merge Join  (cost=319789.90..319798.72 rows=1 width=1138) (actual time=626.010..1595.511 rows=27 loops=1)
               Merge Cond: (tst.token_id = t.token_id)
               ->  Unique  (cost=319789.20..319789.43 rows=45 width=37) (actual time=544.483..544.564 rows=27 loops=1)
                     ->  Sort  (cost=319789.20..319789.32 rows=45 width=37) (actual time=544.482..544.511 rows=27 loops=1)
                           Sort Key: tst.token_id, o.value
                           Sort Method: quicksort  Memory: 27kB
                           ->  Nested Loop  (cost=1.38..319787.97 rows=45 width=37) (actual time=302.355..544.428 rows=27 loops=1)
                                 ->  Index Scan using orders_side_value_source_id_int_contract_index on orders o  (cost=0.56..318919.50 rows=173 width=94) (actual time=105.385..375.378 rows=95 loops=1)
                                       Index Cond: ((side = 'sell'::order_side_t) AND (source_id_int = 1344))
                                 ->  Index Only Scan using token_sets_tokens_pk on token_sets_tokens tst  (cost=0.82..5.00 rows=2 width=138) (actual time=1.766..1.767 rows=0 loops=95)
                                       Index Cond: ((token_set_id = o.token_set_id) AND (contract = '\xbce3781ae7ca1a5e050bd9c4c77369867ebc307e'::bytea))
                                       Heap Fetches: 0
               ->  Index Scan using tokens_collection_id_contract_token_id_index on tokens t  (cost=0.69..8.71 rows=1 width=1101) (actual time=5.153..1047.576 rows=9903 loops=1)
                     Index Cond: ((collection_id = '0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e'::text) AND (contract = '\xbce3781ae7ca1a5e050bd9c4c77369867ebc307e'::bytea))
 Planning Time: 6.485 ms
 Execution Time: 1595.824 ms
```