### PR TITLE
feat: add currency filter to tokens endpoint

### DIFF
--- a/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -93,6 +93,20 @@ export const getTokensV5Options: RouteOptions = {
         .default("floorAskPrice")
         .description("Order the items are returned in the response."),
       sortDirection: Joi.string().lowercase().valid("asc", "desc"),
+      currencies: Joi.alternatives().try(
+        Joi.array()
+          .max(50)
+          .items(Joi.string().lowercase().pattern(regex.address))
+          .description(
+            "Filter to tokens with a listing in a particular currency. `Example: currencies[0]: 0x0000000000000000000000000000000000000000`"
+          ),
+        Joi.string()
+          .lowercase()
+          .pattern(regex.address)
+          .description(
+            "Filter to tokens with a listing in a particular currency. `Example: currencies[0]: 0x0000000000000000000000000000000000000000`"
+          )
+      ),
       limit: Joi.number()
         .integer()
         .min(1)
@@ -374,6 +388,9 @@ export const getTokensV5Options: RouteOptions = {
       sourceConditions.push(
         `o.taker = '\\x0000000000000000000000000000000000000000' OR o.taker IS NULL`
       );
+      if (query.currencies) {
+        sourceConditions.push(`o.currency IN ($/currenciesFilter:raw/)`);
+      }
 
       if (query.contract) {
         sourceConditions.push(`tst.contract = $/contract/`);
@@ -560,6 +577,31 @@ export const getTokensV5Options: RouteOptions = {
 
       if (query.collectionsSetId) {
         conditions.push(`csc.collections_set_id = $/collectionsSetId/`);
+      }
+
+      if (query.currencies) {
+        if (!_.isArray(query.currencies)) {
+          query.currencies = [query.currencies];
+        }
+
+        for (const currency of query.currencies) {
+          const currencyFilter = `'${_.replace(currency, "0x", "\\x")}'`;
+
+          if (_.isUndefined((query as any).currenciesFilter)) {
+            (query as any).currenciesFilter = [];
+          }
+
+          (query as any).currenciesFilter.push(currencyFilter);
+        }
+
+        (query as any).currenciesFilter = _.join((query as any).currenciesFilter, ",");
+
+        if (query.source) {
+          // if source is passed in, then we have two floor_sell_currency columns
+          conditions.push(`s.floor_sell_currency IN ($/currenciesFilter:raw/)`);
+        } else {
+          conditions.push(`floor_sell_currency IN ($/currenciesFilter:raw/)`);
+        }
       }
 
       // Continue with the next page, this depends on the sorting used


### PR DESCRIPTION
Support `currencies` query arg for `/tokens/v5` endpoint.

We refer to currencies by their contract address. (e.g. ETH has address `0x0000000000000000000000000000000000000000`)

Optionally pass in either a single string address or an array of addresses.

When the currency filter is passed in we return the floor price of listings in the filtered currency, similar to what we do with the `source` filter.

Open questions:
1. Is address the right way to refer to a currency?  Should we consider filtering on symbol, like ETH, APE?
2. Is the right query arg `currency` or `currencies`?