### PR TITLE
feat: add price filter to tokens endpoint

### DIFF
--- a/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -85,6 +85,12 @@ export const getTokensV5Options: RouteOptions = {
         .integer()
         .min(1)
         .description("Get tokens with a max rarity rank (inclusive)"),
+      minFloorAskPrice: Joi.number().description(
+        "Get tokens with a min floor ask price (inclusive)"
+      ),
+      maxFloorAskPrice: Joi.number().description(
+        "Get tokens with a max floor ask price (inclusive)"
+      ),
       flagStatus: Joi.number()
         .allow(-1, 0, 1)
         .description("-1 = All tokens (default)\n0 = Non flagged tokens\n1 = Flagged tokens"),
@@ -524,6 +530,24 @@ export const getTokensV5Options: RouteOptions = {
 
       if (query.maxRarityRank) {
         conditions.push(`t.rarity_rank <= $/maxRarityRank/`);
+      }
+
+      if (query.minFloorAskPrice !== undefined) {
+        (query as any).minFloorSellValue = query.minFloorAskPrice * 10 ** 18;
+        conditions.push(
+          `${query.source ? "s." : "t."}${
+            query.normalizeRoyalties ? "normalized_" : ""
+          }floor_sell_value >= $/minFloorSellValue/`
+        );
+      }
+
+      if (query.maxFloorAskPrice !== undefined) {
+        (query as any).maxFloorSellValue = query.maxFloorAskPrice * 10 ** 18;
+        conditions.push(
+          `${query.source ? "s." : "t."}${
+            query.normalizeRoyalties ? "normalized_" : ""
+          }floor_sell_value <= $/maxFloorSellValue/`
+        );
       }
 
       if (query.tokens) {


### PR DESCRIPTION
Add minFloorAskPrice & maxFloorAskPrice to `/tokens/v5` endpoint

Unit is floor sell price converted to ETH.

Open question:
1. Is decimal ETH the right unit? Should we use wei instead?  Passing in ETH does lead to confusing rounding phenomena (e.g. a listing with price 0.11111, with price rounded to 0.11, will be filtered out if filter of max=0.11 is passed in)
2. Is `floorAskPrice` the right terminology to use.