### PR TITLE
Nft trader - sales events

### DIFF
--- a/src/migrations/1670507838754_add-nft-trader-contract-kind.sql
+++ b/src/migrations/1670507838754_add-nft-trader-contract-kind.sql
@@ -1,5 +1,0 @@
--- Up Migration
-
-ALTER TYPE "contract_kind_t" ADD VALUE 'nft-trader';
-
--- Down Migration

--- a/src/migrations/1670507838754_add-nft-trader-contract-kind.sql
+++ b/src/migrations/1670507838754_add-nft-trader-contract-kind.sql
@@ -1,0 +1,5 @@
+-- Up Migration
+
+ALTER TYPE "contract_kind_t" ADD VALUE 'nft-trader';
+
+-- Down Migration

--- a/src/migrations/1670507838754_add-nft-trader-order-kind.sql
+++ b/src/migrations/1670507838754_add-nft-trader-order-kind.sql
@@ -1,0 +1,5 @@
+-- Up Migration
+
+ALTER TYPE "order_kind_t" ADD VALUE 'nft-trader';
+
+-- Down Migration

--- a/src/orderbook/orders/index.ts
+++ b/src/orderbook/orders/index.ts
@@ -53,7 +53,8 @@ export type OrderKind =
   | "forward"
   | "manifold"
   | "tofu-nft"
-  | "decentraland";
+  | "decentraland"
+  | "nft-trader";
 
 // In case we don't have the source of an order readily available, we use
 // a default value where possible (since very often the exchange protocol
@@ -114,6 +115,8 @@ export const getOrderSourceByOrderKind = async (
         return sources.getOrInsert("tofunft.com");
       case "decentraland":
         return sources.getOrInsert("market.decentraland.org");
+      case "nft-trader":
+        return sources.getOrInsert("nfttrader.io");
 
       case "mint": {
         if (address && mintsSources.has(address)) {

--- a/src/sync/events/data/index.ts
+++ b/src/sync/events/data/index.ts
@@ -25,6 +25,7 @@ import * as zeroExV4 from "@/events-sync/data/zeroex-v4";
 import * as zora from "@/events-sync/data/zora";
 import * as manifold from "@/events-sync/data/manifold";
 import * as tofu from "@/events-sync/data/tofu";
+import * as nftTrader from "@/events-sync/data/nft-trader";
 
 // All events we're syncing should have an associated `EventData`
 // entry which dictates the way the event will be parsed and then
@@ -109,7 +110,8 @@ export type EventDataKind =
   | "manifold-cancel"
   | "manifold-finalize"
   | "tofu-inventory-update"
-  | "decentraland-sale";
+  | "decentraland-sale"
+  | "nft-trader-swap";
 
 export type EventData = {
   kind: EventDataKind;
@@ -200,6 +202,7 @@ export const getEventData = (eventDataKinds?: EventDataKind[]) => {
       manifold.cancel,
       tofu.inventoryUpdate,
       decentraland.sale,
+      nftTrader.swap,
     ];
   } else {
     return (
@@ -370,6 +373,8 @@ const internalGetEventData = (kind: EventDataKind): EventData | undefined => {
       return tofu.inventoryUpdate;
     case "decentraland-sale":
       return decentraland.sale;
+    case "nft-trader-swap":
+      return nftTrader.swap;
 
     default:
       return undefined;

--- a/src/sync/events/data/nft-trader.ts
+++ b/src/sync/events/data/nft-trader.ts
@@ -1,0 +1,21 @@
+import { Interface } from "@ethersproject/abi";
+import { EventData } from "@/events-sync/data";
+import { NftTrader } from "@reservoir0x/sdk";
+import { config } from "@/config/index";
+
+export const swap: EventData = {
+  kind: "nft-trader-swap",
+  addresses: { [NftTrader.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0x8873f53f40d4865bac9c1e8998aef3351bb1ef3db1a6923ab09621cf1a6659a9",
+  numTopics: 4,
+  abi: new Interface([
+    `event swapEvent(
+      address indexed creator, 
+      uint256 indexed time, 
+      uint8 indexed status, 
+      uint256 swapId, 
+      address counterpart, 
+      address referral
+      )`,
+  ]),
+};

--- a/src/sync/events/handlers/index.ts
+++ b/src/sync/events/handlers/index.ts
@@ -23,6 +23,7 @@ import * as universe from "@/events-sync/handlers/universe";
 import * as rarible from "@/events-sync/handlers/rarible";
 import * as manifold from "@/events-sync/handlers/manifold";
 import * as tofu from "@/events-sync/handlers/tofu";
+import * as nftTrader from "@/events-sync/handlers/nft-trader";
 
 export type EventsInfo = {
   kind:
@@ -48,7 +49,8 @@ export type EventsInfo = {
     | "rarible"
     | "manifold"
     | "tofu"
-    | "decentraland";
+    | "decentraland"
+    | "nft-trader";
   events: EnhancedEvent[];
   backfill?: boolean;
 };
@@ -166,6 +168,10 @@ export const processEvents = async (info: EventsInfo) => {
     }
     case "tofu": {
       data = await tofu.handleEvents(info.events);
+      break;
+    }
+    case "nft-trader": {
+      data = await nftTrader.handleEvents(info.events);
       break;
     }
   }

--- a/src/sync/events/handlers/nft-trader.ts
+++ b/src/sync/events/handlers/nft-trader.ts
@@ -1,0 +1,204 @@
+import { getEventData } from "@/events-sync/data";
+import { EnhancedEvent, OnChainData } from "@/events-sync/handlers/utils";
+import { parseCallTrace } from "@georgeroman/evm-tx-simulator";
+import * as utils from "@/events-sync/utils";
+import { getUSDAndNativePrices } from "@/utils/prices";
+
+import * as fillUpdates from "@/jobs/fill-updates/queue";
+import * as es from "@/events-sync/storage";
+import { bn } from "@/common/utils";
+
+export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData> => {
+  const fillEvents: es.fills.Event[] = [];
+  const fillInfos: fillUpdates.FillInfo[] = [];
+
+  // Handle the events
+  for (const { kind, baseEventParams, log } of events) {
+    const eventData = getEventData([kind])[0];
+    switch (kind) {
+      case "nft-trader-swap": {
+        const { args } = eventData.abi.parseLog(log);
+        const status = args["status"];
+        const taker = args["creator"].toLowerCase();
+        const orderId = args["swapId"];
+
+        //statuses:
+        // 0 - opened
+        // 1 - closed
+        // 2 - canceled
+        if (status !== 1) {
+          break;
+        }
+
+        const txTrace = await utils.fetchTransactionTrace(baseEventParams.txHash);
+        if (!txTrace) {
+          // Skip any failed attempts to get the trace
+          break;
+        }
+
+        const parsedTrace = parseCallTrace(txTrace.calls);
+
+        let tokenCounterA = 0;
+        let tokenCounterB = 0;
+        let addressesCounter = 0;
+        let tokenId = "";
+        let tokenContract = "";
+        let currency = "";
+        let currencyPrice = "";
+        let maker = "";
+
+        // {
+        //   '0x24deb03382400c993819df42f5adcf897f4f66b3': {
+        //     tokenBalanceState: {
+        //       'native:0x0000000000000000000000000000000000000000': '253700000000000000',
+        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:506': '1',
+        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:2140': '-1'
+        //     }
+        //   },
+        //   '0x657e383edb9a7407e468acbcc9fe4c9730c7c275': {
+        //     tokenBalanceState: {
+        //       'native:0x0000000000000000000000000000000000000000': '-265000000000000000'
+        //     }
+        //   },
+        //   '0xfe20d3b9419d37bc1a9c65fdd0a66109fffd5f43': {
+        //     tokenBalanceState: {
+        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:506': '-1',
+        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:2140': '1'
+        //     }
+        //   },
+        //   '0x83db44123e76503203fdf83d2be58be60c15b894': {
+        //     tokenBalanceState: {
+        //       'native:0x0000000000000000000000000000000000000000': '11300000000000000'
+        //     }
+        //   }
+        // }
+
+        // {
+        //   "0x10a89eacfc556e4f943050eafc350d3c1122836a": {
+        //     tokenBalanceState: {
+        //       "native:0x0000000000000000000000000000000000000000": "-3805000000000000000",
+        //       "erc721:0x231d3559aa848bf10366fb9868590f01d34bf240:1475": "1",
+        //     },
+        //   },
+        //   "0x657e383edb9a7407e468acbcc9fe4c9730c7c275": {
+        //     tokenBalanceState: {
+        //       "native:0x0000000000000000000000000000000000000000": "-5000000000000000",
+        //     },
+        //   },
+        //   "0xce9f867f70d1db3a37db2cda0d0eec099020f695": {
+        //     tokenBalanceState: {
+        //       "erc721:0x231d3559aa848bf10366fb9868590f01d34bf240:1475": "-1",
+        //       "native:0x0000000000000000000000000000000000000000": "3781000000000000000",
+        //     },
+        //   },
+        //   "0x83db44123e76503203fdf83d2be58be60c15b894": {
+        //     tokenBalanceState: {
+        //       "native:0x0000000000000000000000000000000000000000": "29000000000000000",
+        //     },
+        //   },
+        // }
+
+        let transferToken = "";
+        let amount = "0";
+        let currencyType = "";
+        for (const token of Object.keys(parsedTrace[taker].tokenBalanceState)) {
+          if (token.startsWith("erc721") || token.startsWith("erc1155")) {
+            transferToken = token;
+
+            amount = parsedTrace[taker].tokenBalanceState[token];
+          } else if (token.startsWith("erc20") || token.startsWith("native")) {
+            currency = token.split(":")[1];
+            currencyType = token;
+          }
+        }
+
+        for (const address of Object.keys(parsedTrace)) {
+          if (address === baseEventParams.address) {
+            continue;
+          }
+
+          for (const token of Object.keys(parsedTrace[address].tokenBalanceState)) {
+            if (token.startsWith("erc721") || token.startsWith("erc1155")) {
+              addressesCounter === 0 ? tokenCounterA++ : tokenCounterB++;
+              addressesCounter++;
+
+              if (address !== taker && token === transferToken) {
+                maker = address;
+              }
+
+              [, tokenContract, tokenId] = token.split(":");
+            }
+          }
+        }
+
+        //we don't support token for token exchange
+        //we don't support bundles
+        if ((tokenCounterA && tokenCounterB) || tokenCounterA > 1 || tokenCounterB > 1) {
+          break;
+        }
+
+        if (bn(amount).gt(0)) {
+          currencyPrice = bn(parsedTrace[taker].tokenBalanceState[currencyType])
+            .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyType]))
+            .toString();
+        } else {
+          currencyPrice = bn(parsedTrace[maker].tokenBalanceState[currencyType])
+            .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyType]))
+            .toString();
+        }
+
+        const priceData = await getUSDAndNativePrices(
+          currency,
+          currencyPrice.toString(),
+          baseEventParams.timestamp
+        );
+        if (!priceData.nativePrice) {
+          // We must always have the native price
+          break;
+        }
+
+        const orderKind = "nft-trader";
+        const attributionData = await utils.extractAttributionData(
+          baseEventParams.txHash,
+          orderKind
+        );
+
+        // break;
+        fillEvents.push({
+          orderKind,
+          currency,
+          orderSide: bn(amount).gt(0) ? "sell" : "buy",
+          maker,
+          taker,
+          price: priceData.nativePrice,
+          currencyPrice,
+          usdPrice: priceData.usdPrice,
+          contract: tokenContract,
+          tokenId,
+          amount,
+          orderSourceId: attributionData.orderSource?.id,
+          aggregatorSourceId: attributionData.aggregatorSource?.id,
+          fillSourceId: attributionData.fillSource?.id,
+          baseEventParams,
+        });
+
+        fillInfos.push({
+          context: `nft-trader-${tokenContract}-${tokenId}-${orderId}-${baseEventParams.txHash}`,
+          orderSide: "buy",
+          contract: tokenContract,
+          tokenId,
+          amount,
+          price: priceData.nativePrice,
+          timestamp: baseEventParams.timestamp,
+        });
+
+        break;
+      }
+    }
+  }
+
+  return {
+    fillEvents,
+    fillInfos,
+  };
+};

--- a/src/sync/events/handlers/nft-trader.ts
+++ b/src/sync/events/handlers/nft-trader.ts
@@ -20,9 +20,8 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
         const { args } = eventData.abi.parseLog(log);
         const status = args["status"];
         const taker = args["creator"].toLowerCase();
-        const orderId = args["swapId"];
 
-        //statuses:
+        // statuses:
         // 0 - opened
         // 1 - closed
         // 2 - canceled
@@ -38,114 +37,58 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
 
         const parsedTrace = parseCallTrace(txTrace.calls);
 
-        let tokenCounterA = 0;
-        let tokenCounterB = 0;
-        let addressesCounter = 0;
+        let transferedTokensCounter = 0;
         let tokenId = "";
         let tokenContract = "";
         let currency = "";
         let currencyPrice = "";
         let maker = "";
 
-        // {
-        //   '0x24deb03382400c993819df42f5adcf897f4f66b3': {
-        //     tokenBalanceState: {
-        //       'native:0x0000000000000000000000000000000000000000': '253700000000000000',
-        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:506': '1',
-        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:2140': '-1'
-        //     }
-        //   },
-        //   '0x657e383edb9a7407e468acbcc9fe4c9730c7c275': {
-        //     tokenBalanceState: {
-        //       'native:0x0000000000000000000000000000000000000000': '-265000000000000000'
-        //     }
-        //   },
-        //   '0xfe20d3b9419d37bc1a9c65fdd0a66109fffd5f43': {
-        //     tokenBalanceState: {
-        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:506': '-1',
-        //       'erc721:0x64a1c0937728d8d2fa8cd81ef61a9c860b7362db:2140': '1'
-        //     }
-        //   },
-        //   '0x83db44123e76503203fdf83d2be58be60c15b894': {
-        //     tokenBalanceState: {
-        //       'native:0x0000000000000000000000000000000000000000': '11300000000000000'
-        //     }
-        //   }
-        // }
-
-        // {
-        //   "0x10a89eacfc556e4f943050eafc350d3c1122836a": {
-        //     tokenBalanceState: {
-        //       "native:0x0000000000000000000000000000000000000000": "-3805000000000000000",
-        //       "erc721:0x231d3559aa848bf10366fb9868590f01d34bf240:1475": "1",
-        //     },
-        //   },
-        //   "0x657e383edb9a7407e468acbcc9fe4c9730c7c275": {
-        //     tokenBalanceState: {
-        //       "native:0x0000000000000000000000000000000000000000": "-5000000000000000",
-        //     },
-        //   },
-        //   "0xce9f867f70d1db3a37db2cda0d0eec099020f695": {
-        //     tokenBalanceState: {
-        //       "erc721:0x231d3559aa848bf10366fb9868590f01d34bf240:1475": "-1",
-        //       "native:0x0000000000000000000000000000000000000000": "3781000000000000000",
-        //     },
-        //   },
-        //   "0x83db44123e76503203fdf83d2be58be60c15b894": {
-        //     tokenBalanceState: {
-        //       "native:0x0000000000000000000000000000000000000000": "29000000000000000",
-        //     },
-        //   },
-        // }
-
         let transferToken = "";
         let amount = "0";
         let currencyType = "";
+
         for (const token of Object.keys(parsedTrace[taker].tokenBalanceState)) {
           if (token.startsWith("erc721") || token.startsWith("erc1155")) {
             transferToken = token;
-
+            transferedTokensCounter++;
             amount = parsedTrace[taker].tokenBalanceState[token];
+            [, tokenContract, tokenId] = token.split(":");
           } else if (token.startsWith("erc20") || token.startsWith("native")) {
-            currency = token.split(":")[1];
             currencyType = token;
+            currency = token.split(":")[1];
           }
         }
 
-        for (const address of Object.keys(parsedTrace)) {
-          if (address === baseEventParams.address) {
-            continue;
-          }
-
+        for (const address of Object.keys(parsedTrace).filter(
+          (key) => baseEventParams.address !== key
+        )) {
           for (const token of Object.keys(parsedTrace[address].tokenBalanceState)) {
-            if (token.startsWith("erc721") || token.startsWith("erc1155")) {
-              addressesCounter === 0 ? tokenCounterA++ : tokenCounterB++;
-              addressesCounter++;
-
-              if (address !== taker && token === transferToken) {
-                maker = address;
-              }
-
-              [, tokenContract, tokenId] = token.split(":");
+            if (address !== taker && token === transferToken) {
+              maker = address;
             }
           }
         }
 
-        //we don't support token for token exchange
-        //we don't support bundles
-        if ((tokenCounterA && tokenCounterB) || tokenCounterA > 1 || tokenCounterB > 1) {
+        // we don't support token for token exchange
+        // we don't support bundles
+        if (transferedTokensCounter !== 1) {
           break;
         }
 
-        if (bn(amount).gt(0)) {
-          currencyPrice = bn(parsedTrace[taker].tokenBalanceState[currencyType])
-            .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyType]))
-            .toString();
-        } else {
-          currencyPrice = bn(parsedTrace[maker].tokenBalanceState[currencyType])
-            .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyType]))
-            .toString();
-        }
+        // depending on the order side we have to calculate:
+        // price when order is "sale" = taker price paid + conctract fee
+        // price when order is "buy" = maker price received + concract fee
+        const orderSide = bn(amount).gt(0) ? "sell" : "buy";
+
+        currencyPrice = bn(
+          parsedTrace[orderSide === "sell" ? taker : maker].tokenBalanceState[currencyType]
+        )
+          .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyType]))
+          .abs()
+          .toString();
+
+        amount = bn(amount).abs().toString();
 
         const priceData = await getUSDAndNativePrices(
           currency,
@@ -163,11 +106,10 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
           orderKind
         );
 
-        // break;
         fillEvents.push({
           orderKind,
           currency,
-          orderSide: bn(amount).gt(0) ? "sell" : "buy",
+          orderSide,
           maker,
           taker,
           price: priceData.nativePrice,
@@ -183,8 +125,8 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
         });
 
         fillInfos.push({
-          context: `nft-trader-${tokenContract}-${tokenId}-${orderId}-${baseEventParams.txHash}`,
-          orderSide: "buy",
+          context: `nft-trader-${tokenContract}-${tokenId}-${baseEventParams.txHash}`,
+          orderSide,
           contract: tokenContract,
           tokenId,
           amount,

--- a/src/sync/events/handlers/nft-trader.ts
+++ b/src/sync/events/handlers/nft-trader.ts
@@ -44,18 +44,18 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
         let currencyPrice = "";
         let maker = "";
 
-        let transferToken = "";
+        let tokenKey = "";
         let amount = "0";
-        let currencyType = "";
+        let currencyKey = "";
 
         for (const token of Object.keys(parsedTrace[taker].tokenBalanceState)) {
           if (token.startsWith("erc721") || token.startsWith("erc1155")) {
-            transferToken = token;
+            tokenKey = token;
             transferedTokensCounter++;
             amount = parsedTrace[taker].tokenBalanceState[token];
             [, tokenContract, tokenId] = token.split(":");
           } else if (token.startsWith("erc20") || token.startsWith("native")) {
-            currencyType = token;
+            currencyKey = token;
             currency = token.split(":")[1];
           }
         }
@@ -64,7 +64,7 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
           (key) => baseEventParams.address !== key
         )) {
           for (const token of Object.keys(parsedTrace[address].tokenBalanceState)) {
-            if (address !== taker && token === transferToken) {
+            if (address !== taker && token === tokenKey) {
               maker = address;
             }
           }
@@ -82,9 +82,9 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
         const orderSide = bn(amount).gt(0) ? "sell" : "buy";
 
         currencyPrice = bn(
-          parsedTrace[orderSide === "sell" ? taker : maker].tokenBalanceState[currencyType]
+          parsedTrace[orderSide === "sell" ? taker : maker].tokenBalanceState[currencyKey]
         )
-          .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyType]))
+          .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyKey]))
           .abs()
           .toString();
 

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -291,10 +291,12 @@ export const syncEvents = async (
       {
         kind: "tofu",
         events: enhancedEvents.filter(({ kind }) => kind.startsWith("tofu")),
+        backfill,
       },
       {
         kind: "nft-trader",
         events: enhancedEvents.filter(({ kind }) => kind.startsWith("nft-trader")),
+        backfill,
       },
     ]);
 

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -291,7 +291,10 @@ export const syncEvents = async (
       {
         kind: "tofu",
         events: enhancedEvents.filter(({ kind }) => kind.startsWith("tofu")),
-        backfill,
+      },
+      {
+        kind: "nft-trader",
+        events: enhancedEvents.filter(({ kind }) => kind.startsWith("nft-trader")),
       },
     ]);
 


### PR DESCRIPTION
This implementation is only tracking sales events for NftTrader.io integration.
With this PR we only keep track of ERC20/ETH <-> ERC721/ERC1155 trades.

SDK PR: https://github.com/reservoirprotocol/core/pull/67