### PR TITLE
fix: rarity rank filter check undefined

### DIFF
--- a/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -79,9 +79,11 @@ export const getTokensV5Options: RouteOptions = {
       ),
       minRarityRank: Joi.number()
         .integer()
+        .min(1)
         .description("Get tokens with a min rarity rank (inclusive)"),
       maxRarityRank: Joi.number()
         .integer()
+        .min(1)
         .description("Get tokens with a max rarity rank (inclusive)"),
       flagStatus: Joi.number()
         .allow(-1, 0, 1)


### PR DESCRIPTION
Passing in min/maxRarityRank = 0 leads to a bug

@ipeleg 