### PR TITLE
Add Okex sales handling

### DIFF
--- a/src/migrations/1671178196392_add-okex-order-kind.sql
+++ b/src/migrations/1671178196392_add-okex-order-kind.sql
@@ -1,0 +1,5 @@
+-- Up Migration
+
+ALTER TYPE "order_kind_t" ADD VALUE 'okex';
+
+-- Down Migration

--- a/src/orderbook/orders/index.ts
+++ b/src/orderbook/orders/index.ts
@@ -54,7 +54,8 @@ export type OrderKind =
   | "manifold"
   | "tofu-nft"
   | "decentraland"
-  | "nft-trader";
+  | "nft-trader"
+  | "okex";
 
 // In case we don't have the source of an order readily available, we use
 // a default value where possible (since very often the exchange protocol
@@ -117,6 +118,8 @@ export const getOrderSourceByOrderKind = async (
         return sources.getOrInsert("market.decentraland.org");
       case "nft-trader":
         return sources.getOrInsert("nfttrader.io");
+      case "okex":
+        return sources.getOrInsert("okx.com");
 
       case "mint": {
         if (address && mintsSources.has(address)) {

--- a/src/sync/events/data/index.ts
+++ b/src/sync/events/data/index.ts
@@ -26,6 +26,7 @@ import * as zora from "@/events-sync/data/zora";
 import * as manifold from "@/events-sync/data/manifold";
 import * as tofu from "@/events-sync/data/tofu";
 import * as nftTrader from "@/events-sync/data/nft-trader";
+import * as okex from "@/events-sync/data/okex";
 
 // All events we're syncing should have an associated `EventData`
 // entry which dictates the way the event will be parsed and then
@@ -111,7 +112,8 @@ export type EventDataKind =
   | "manifold-finalize"
   | "tofu-inventory-update"
   | "decentraland-sale"
-  | "nft-trader-swap";
+  | "nft-trader-swap"
+  | "okex-order-filled";
 
 export type EventData = {
   kind: EventDataKind;
@@ -203,6 +205,7 @@ export const getEventData = (eventDataKinds?: EventDataKind[]) => {
       tofu.inventoryUpdate,
       decentraland.sale,
       nftTrader.swap,
+      okex.orderFulfilled,
     ];
   } else {
     return (
@@ -375,6 +378,8 @@ const internalGetEventData = (kind: EventDataKind): EventData | undefined => {
       return decentraland.sale;
     case "nft-trader-swap":
       return nftTrader.swap;
+    case "okex-order-filled":
+      return okex.orderFulfilled;
 
     default:
       return undefined;

--- a/src/sync/events/data/okex.ts
+++ b/src/sync/events/data/okex.ts
@@ -1,0 +1,33 @@
+import { Interface } from "@ethersproject/abi";
+import { Okex } from "@reservoir0x/sdk";
+
+import { config } from "@/config/index";
+import { EventData } from "@/events-sync/data";
+
+export const orderFulfilled: EventData = {
+  kind: "okex-order-filled",
+  addresses: { [Okex.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31",
+  numTopics: 3,
+  abi: new Interface([
+    `event OrderFulfilled(
+      bytes32 orderHash,
+      address indexed offerer,
+      address indexed zone,
+      address recipient,
+      (
+        uint8 itemType,
+        address token,
+        uint256 identifier,
+        uint256 amount
+      )[] offer,
+      (
+        uint8 itemType,
+        address token,
+        uint256 identifier,
+        uint256 amount,
+        address recipient
+      )[] consideration
+    )`,
+  ]),
+};

--- a/src/sync/events/handlers/index.ts
+++ b/src/sync/events/handlers/index.ts
@@ -24,6 +24,7 @@ import * as rarible from "@/events-sync/handlers/rarible";
 import * as manifold from "@/events-sync/handlers/manifold";
 import * as tofu from "@/events-sync/handlers/tofu";
 import * as nftTrader from "@/events-sync/handlers/nft-trader";
+import * as okex from "@/events-sync/handlers/okex";
 
 export type EventsInfo = {
   kind:
@@ -50,7 +51,8 @@ export type EventsInfo = {
     | "manifold"
     | "tofu"
     | "decentraland"
-    | "nft-trader";
+    | "nft-trader"
+    | "okex";
   events: EnhancedEvent[];
   backfill?: boolean;
 };
@@ -162,16 +164,24 @@ export const processEvents = async (info: EventsInfo) => {
       data = await rarible.handleEvents(info.events);
       break;
     }
+
     case "manifold": {
       data = await manifold.handleEvents(info.events);
       break;
     }
+
     case "tofu": {
       data = await tofu.handleEvents(info.events);
       break;
     }
+
     case "nft-trader": {
       data = await nftTrader.handleEvents(info.events);
+      break;
+    }
+
+    case "okex": {
+      data = await okex.handleEvents(info.events);
       break;
     }
   }

--- a/src/sync/events/handlers/okex.ts
+++ b/src/sync/events/handlers/okex.ts
@@ -1,0 +1,107 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { bn } from "@/common/utils";
+import { config } from "@/config/index";
+import { getEventData } from "@/events-sync/data";
+import { EnhancedEvent, OnChainData } from "@/events-sync/handlers/utils";
+import * as es from "@/events-sync/storage";
+import * as utils from "@/events-sync/utils";
+import { getUSDAndNativePrices } from "@/utils/prices";
+
+import * as fillUpdates from "@/jobs/fill-updates/queue";
+
+export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData> => {
+  const fillEventsPartial: es.fills.Event[] = [];
+
+  const fillInfos: fillUpdates.FillInfo[] = [];
+
+  // Handle the events
+  for (const { kind, baseEventParams, log } of events) {
+    const eventData = getEventData([kind])[0];
+    switch (kind) {
+      case "okex-order-filled": {
+        const parsedLog = eventData.abi.parseLog(log);
+        const orderId = parsedLog.args["orderHash"].toLowerCase();
+        const maker = parsedLog.args["offerer"].toLowerCase();
+        let taker = parsedLog.args["recipient"].toLowerCase();
+        const offer = parsedLog.args["offer"];
+        const consideration = parsedLog.args["consideration"];
+
+        // TODO: Switch to `Okex` class once integrated
+        const saleInfo = new Sdk.Seaport.Exchange(config.chainId).deriveBasicSale(
+          offer,
+          consideration
+        );
+        if (saleInfo) {
+          // Handle: attribution
+
+          const orderKind = "okex";
+          const attributionData = await utils.extractAttributionData(
+            baseEventParams.txHash,
+            orderKind
+          );
+          if (attributionData.taker) {
+            taker = attributionData.taker;
+          }
+
+          if (saleInfo.recipientOverride) {
+            taker = saleInfo.recipientOverride;
+          }
+
+          // Handle: prices
+
+          const currency = saleInfo.paymentToken;
+          const currencyPrice = bn(saleInfo.price).div(saleInfo.amount).toString();
+          const priceData = await getUSDAndNativePrices(
+            currency,
+            currencyPrice,
+            baseEventParams.timestamp
+          );
+          if (!priceData.nativePrice) {
+            // We must always have the native price
+            break;
+          }
+
+          const orderSide = saleInfo.side as "sell" | "buy";
+          fillEventsPartial.push({
+            orderKind,
+            orderId,
+            orderSide,
+            maker,
+            taker,
+            price: priceData.nativePrice,
+            currency,
+            currencyPrice,
+            usdPrice: priceData.usdPrice,
+            contract: saleInfo.contract,
+            tokenId: saleInfo.tokenId,
+            amount: saleInfo.amount,
+            orderSourceId: attributionData.orderSource?.id,
+            aggregatorSourceId: attributionData.aggregatorSource?.id,
+            fillSourceId: attributionData.fillSource?.id,
+            baseEventParams,
+          });
+
+          fillInfos.push({
+            context: `${orderId}-${baseEventParams.txHash}`,
+            orderId: orderId,
+            orderSide,
+            contract: saleInfo.contract,
+            tokenId: saleInfo.tokenId,
+            amount: saleInfo.amount,
+            price: priceData.nativePrice,
+            timestamp: baseEventParams.timestamp,
+          });
+        }
+
+        break;
+      }
+    }
+  }
+
+  return {
+    fillEventsPartial,
+
+    fillInfos,
+  };
+};

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -296,6 +296,10 @@ export const syncEvents = async (
       {
         kind: "nft-trader",
         events: enhancedEvents.filter(({ kind }) => kind.startsWith("nft-trader")),
+      },
+      {
+        kind: "okex",
+        events: enhancedEvents.filter(({ kind }) => kind.startsWith("okex")),
         backfill,
       },
     ]);

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -296,6 +296,7 @@ export const syncEvents = async (
       {
         kind: "nft-trader",
         events: enhancedEvents.filter(({ kind }) => kind.startsWith("nft-trader")),
+        backfill,
       },
       {
         kind: "okex",


### PR DESCRIPTION
Okex exchange contract isn't verified on etherscan but I noticed that it's event hash and event topics count matche the ones from seaport and noun so I decided to reuse the event handling logic from them. Tested with a few sale transactions and it seems to me that the event are being parsed correctly.

SDK PR: https://github.com/reservoirprotocol/core/pull/68