### PR TITLE
Order addresses to avoid deadlock on ft balance update

### DIFF
--- a/src/sync/events/storage/ft-transfer-events.ts
+++ b/src/sync/events/storage/ft-transfer-events.ts
@@ -95,6 +95,7 @@ export const addEvents = async (events: Event[], backfill: boolean) => {
             unnest("owners") AS "owner",
             unnest("amount_deltas") AS "amount_delta"
           FROM "x"
+          ORDER BY "owner" ASC
         ) "y"
         GROUP BY "y"."address", "y"."owner"
       )


### PR DESCRIPTION
Add order by clause to keep consistent address order on balance updates