### PR TITLE
fix: add try catch to avoid errors from faulty transaction parsing

### DIFF
--- a/src/sync/events/handlers/nft-trader.ts
+++ b/src/sync/events/handlers/nft-trader.ts
@@ -82,15 +82,21 @@ export const handleEvents = async (events: EnhancedEvent[]): Promise<OnChainData
         // Price when order is "buy" = maker price received + concract fee
         const orderSide = bn(amount).gt(0) ? "sell" : "buy";
 
-        if (orderSide === "sell") {
-          currencyPrice = bn(parsedTrace[taker].tokenBalanceState[currencyKey])
-            .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyKey]))
-            .abs()
-            .toString();
-        } else {
-          currencyPrice = bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyKey])
-            .abs()
-            .toString();
+        // This try catch block is used to avoid errors from a few faulty nft-trader transactions
+        // that are not getting parsed properly
+        try {
+          if (orderSide === "sell") {
+            currencyPrice = bn(parsedTrace[taker].tokenBalanceState[currencyKey])
+              .add(bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyKey]))
+              .abs()
+              .toString();
+          } else {
+            currencyPrice = bn(parsedTrace[baseEventParams.address].tokenBalanceState[currencyKey])
+              .abs()
+              .toString();
+          }
+        } catch (error) {
+          break;
         }
 
         amount = bn(amount).abs().toString();


### PR DESCRIPTION
Adding try catch block in nft trader price calculations to avoid errors from a few faulty transactions