### PR TITLE
fix: use decoded zeroex-v2 asset data instead of trace

### DIFF
--- a/src/sync/events/handlers/zeroex-v2.ts
+++ b/src/sync/events/handlers/zeroex-v2.ts
@@ -84,7 +84,7 @@ export const handleEvents = async (events: EnhancedEvent[], onChainData: OnChain
         tokenContract = orderSide === "sell" ? decodedMakerAssetData[0] : decodedTakerAssetData[0];
         tokenId = orderSide === "sell" ? decodedMakerAssetData[1] : decodedTakerAssetData[1];
 
-        if (currency === Sdk.ZeroExV2.Addresses.Eth[config.chainId]) {
+        if (currency === Sdk.ZeroExV4.Addresses.Eth[config.chainId]) {
           // Map the weird ZeroEx ETH address to the default ETH address
           currency = Sdk.Common.Addresses.Eth[config.chainId];
         }

--- a/src/sync/events/handlers/zeroex-v2.ts
+++ b/src/sync/events/handlers/zeroex-v2.ts
@@ -25,6 +25,13 @@ export const handleEvents = async (events: EnhancedEvent[], onChainData: OnChain
         const ERC20Proxy = "0xf47261b0";
         const ERC721Proxy = "0x02571792";
 
+        if (
+          args["takerAssetData"].slice(0, 10) !== MultiAssetProxy ||
+          args["makerAssetData"].slice(0, 10) !== MultiAssetProxy
+        ) {
+          break;
+        }
+
         const takerAssetData = defaultAbiCoder.decode(
           ["uint256[]", "bytes[]"],
           args["takerAssetData"].replace(MultiAssetProxy, "0x")

--- a/src/sync/events/handlers/zeroex-v2.ts
+++ b/src/sync/events/handlers/zeroex-v2.ts
@@ -1,10 +1,10 @@
-import { parseCallTrace } from "@georgeroman/evm-tx-simulator";
-
-import { bn } from "@/common/utils";
+import * as Sdk from "@reservoir0x/sdk";
+import { config } from "@/config/index";
 import { getEventData } from "@/events-sync/data";
 import { EnhancedEvent, OnChainData } from "@/events-sync/handlers/utils";
 import * as utils from "@/events-sync/utils";
 import { getUSDAndNativePrices } from "@/utils/prices";
+import { defaultAbiCoder } from "@ethersproject/abi";
 
 export const handleEvents = async (events: EnhancedEvent[], onChainData: OnChainData) => {
   // Handle the events
@@ -15,42 +15,79 @@ export const handleEvents = async (events: EnhancedEvent[], onChainData: OnChain
         const { args } = eventData.abi.parseLog(log);
         const maker = args["makerAddress"].toLowerCase();
         const taker = args["takerAddress"].toLowerCase();
-        let transferredTokensCounter = 0;
         let amount = "";
         let tokenContract = "";
         let tokenId = "";
-        let currencyKey = "";
         let currency = "";
         let currencyPrice = "";
 
-        const txTrace = await utils.fetchTransactionTrace(baseEventParams.txHash);
-        if (!txTrace) {
-          // Skip any failed attempts to get the trace
+        const MultiAssetProxy = "0x94cfcdd7";
+        const ERC20Proxy = "0xf47261b0";
+        const ERC721Proxy = "0x02571792";
+
+        const takerAssetData = defaultAbiCoder.decode(
+          ["uint256[]", "bytes[]"],
+          args["takerAssetData"].replace(MultiAssetProxy, "0x")
+        );
+        const makerAssetData = defaultAbiCoder.decode(
+          ["uint256[]", "bytes[]"],
+          args["makerAssetData"].replace(MultiAssetProxy, "0x")
+        );
+
+        if (makerAssetData[1].length !== 1 || takerAssetData[1].length !== 1) {
           break;
         }
 
-        const parsedTrace = parseCallTrace(txTrace.calls);
+        const makerAssetType = makerAssetData[1][0].slice(0, 10);
+        const takerAssetType = takerAssetData[1][0].slice(0, 10);
 
-        for (const token of Object.keys(parsedTrace[taker].tokenBalanceState)) {
-          if (token.startsWith("erc721") || token.startsWith("erc1155")) {
-            transferredTokensCounter++;
-            amount = parsedTrace[taker].tokenBalanceState[token];
-            [, tokenContract, tokenId] = token.split(":");
-          } else if (token.startsWith("erc20") || token.startsWith("native")) {
-            currencyKey = token;
-            currency = token.split(":")[1];
-          }
-        }
-
-        // We don't support token for token exchange
-        // We don't support bundles
-        if (transferredTokensCounter !== 1) {
+        if (
+          MultiAssetProxy in [makerAssetType, takerAssetType] ||
+          makerAssetType === takerAssetType
+        ) {
           break;
         }
 
-        const orderSide = bn(amount).gt(0) ? "sell" : "buy";
-        currencyPrice = bn(parsedTrace[taker].tokenBalanceState[currencyKey]).abs().toString();
-        amount = bn(amount).abs().toString();
+        const orderSide = makerAssetType === ERC20Proxy ? "buy" : "sell";
+
+        // Decode taker asset data
+        let decodedTakerAssetData = null;
+        if (takerAssetType === ERC721Proxy) {
+          decodedTakerAssetData = defaultAbiCoder.decode(
+            ["address", "uint256"],
+            takerAssetData[1][0].replace(ERC721Proxy, "0x")
+          );
+        } else {
+          decodedTakerAssetData = defaultAbiCoder.decode(
+            ["address"],
+            takerAssetData[1][0].replace(ERC20Proxy, "0x")
+          );
+        }
+
+        // Decode maker asset data
+        let decodedMakerAssetData = null;
+        if (makerAssetType === ERC721Proxy) {
+          decodedMakerAssetData = defaultAbiCoder.decode(
+            ["address", "uint256"],
+            makerAssetData[1][0].replace(ERC721Proxy, "0x")
+          );
+        } else {
+          decodedMakerAssetData = defaultAbiCoder.decode(
+            ["address"],
+            makerAssetData[1][0].replace(ERC20Proxy, "0x")
+          );
+        }
+
+        currency = orderSide === "sell" ? decodedTakerAssetData[0] : decodedMakerAssetData[0];
+        currencyPrice = orderSide === "sell" ? takerAssetData[0][0] : makerAssetData[0][0];
+        amount = orderSide === "sell" ? makerAssetData[0][0] : takerAssetData[0][0];
+        tokenContract = orderSide === "sell" ? decodedMakerAssetData[0] : decodedTakerAssetData[0];
+        tokenId = orderSide === "sell" ? decodedMakerAssetData[1] : decodedTakerAssetData[1];
+
+        if (currency === Sdk.ZeroExV2.Addresses.Eth[config.chainId]) {
+          // Map the weird ZeroEx ETH address to the default ETH address
+          currency = Sdk.Common.Addresses.Eth[config.chainId];
+        }
 
         const priceData = await getUSDAndNativePrices(
           currency,

--- a/src/sync/events/index.ts
+++ b/src/sync/events/index.ts
@@ -223,10 +223,10 @@ export const extractEventsBatches = async (
                 ]
               : [],
           },
-          // {
-          //   kind: "zeroex-v2",
-          //   data: kindToEvents.get("zeroex-v2") ?? [],
-          // },
+          {
+            kind: "zeroex-v2",
+            data: kindToEvents.get("zeroex-v2") ?? [],
+          },
         ];
 
         txHashToEventsBatch.set(txHash, {


### PR DESCRIPTION
SDK: https://github.com/reservoirprotocol/core/pull/82