### PR TITLE
feat: royalties detection improve

### DIFF
--- a/src/api/endpoints/transfers/get-sales/v4.ts
+++ b/src/api/endpoints/transfers/get-sales/v4.ts
@@ -378,7 +378,7 @@ export const getSalesV4Options: RouteOptions = {
           marketplaceFeeBps:
             r.marketplace_fee_bps !== null && feeInfoIsValid ? r.marketplace_fee_bps : undefined,
           paidFullRoyalty:
-            r.paid_full_royalty !== null && feeInfoIsValid ? r.paid_full_royalty : undefined,
+            r.paid_full_royalty !== null && feeInfoIsValid ? r.paid_full_royalty : false,
           feeBreakdown:
             (r.royalty_fee_breakdown !== null || r.marketplace_fee_breakdown !== null) &&
             feeInfoIsValid

--- a/src/jobs/events-sync/process/backfill.ts
+++ b/src/jobs/events-sync/process/backfill.ts
@@ -56,7 +56,7 @@ if (config.doBackgroundWork && (config.chainId === 137 ? !config.doEventsSyncBac
         }
       }
     },
-    { connection: redis.duplicate(), concurrency: 10 }
+    { connection: redis.duplicate(), concurrency: 30 }
   );
 
   worker.on("error", (error) => {

--- a/src/jobs/events-sync/process/backfill.ts
+++ b/src/jobs/events-sync/process/backfill.ts
@@ -56,7 +56,7 @@ if (config.doBackgroundWork && (config.chainId === 137 ? !config.doEventsSyncBac
         }
       }
     },
-    { connection: redis.duplicate(), concurrency: 30 }
+    { connection: redis.duplicate(), concurrency: 50 }
   );
 
   worker.on("error", (error) => {

--- a/src/jobs/events-sync/process/backfill.ts
+++ b/src/jobs/events-sync/process/backfill.ts
@@ -25,7 +25,7 @@ export const queue = new Queue(QUEUE_NAME, {
 new QueueScheduler(QUEUE_NAME, { connection: redis.duplicate(), maxStalledCount: 10 });
 
 // BACKGROUND WORKER ONLY
-if (config.doBackgroundWork) {
+if (config.doBackgroundWork && (config.chainId === 137 ? !config.doEventsSyncBackfill : true)) {
   const worker = new Worker(
     QUEUE_NAME,
     async (job) => {

--- a/src/jobs/events-sync/write-buffers/nft-transfers.ts
+++ b/src/jobs/events-sync/write-buffers/nft-transfers.ts
@@ -25,7 +25,7 @@ export const queue = new Queue(QUEUE_NAME, {
 new QueueScheduler(QUEUE_NAME, { connection: redis.duplicate() });
 
 // BACKGROUND WORKER ONLY
-if (config.doBackgroundWork && config.railwayStaticUrl) {
+if (config.doBackgroundWork && (config.chainId === 137 ? config.doEventsSyncBackfill : true)) {
   const worker = new Worker(
     QUEUE_NAME,
     async (job: Job) => {

--- a/src/jobs/events-sync/write-buffers/nft-transfers.ts
+++ b/src/jobs/events-sync/write-buffers/nft-transfers.ts
@@ -48,7 +48,7 @@ if (config.doBackgroundWork && (config.chainId === 137 ? config.doEventsSyncBack
     },
     {
       connection: redis.duplicate(),
-      concurrency: 10,
+      concurrency: 15,
     }
   );
 

--- a/src/sync/events/handlers/royalties/config.ts
+++ b/src/sync/events/handlers/royalties/config.ts
@@ -3,19 +3,27 @@ import * as Sdk from "@reservoir0x/sdk";
 import { config } from "@/config/index";
 
 export const platformFeeRecipientsRegistry: Map<string, string[]> = new Map();
+export const allPlatformFeeRecipients = new Set();
 
-platformFeeRecipientsRegistry.set("seaport", [
+function addPlatformAddress(type: string, addrList: string[]) {
+  platformFeeRecipientsRegistry.set(type, addrList);
+  addrList.forEach((address) => allPlatformFeeRecipients.add(address));
+}
+
+addPlatformAddress("seaport", [
   "0x5b3256965e7c3cf26e11fcaf296dfc8807c01073",
   "0x8de9c5a032463c561423387a9648c5c7bcc5bc90",
   "0x0000a26b00c1f0df003000390027140000faa719",
 ]);
-platformFeeRecipientsRegistry.set("seaport-v1.2", [
+
+addPlatformAddress("seaport-v1.2", [
   "0x5b3256965e7c3cf26e11fcaf296dfc8807c01073",
   "0x8de9c5a032463c561423387a9648c5c7bcc5bc90",
   "0x0000a26b00c1f0df003000390027140000faa719",
 ]);
-platformFeeRecipientsRegistry.set("looks-rare", ["0x5924a28caaf1cc016617874a2f0c3710d881f3c1"]);
-platformFeeRecipientsRegistry.set("x2y2", [Sdk.X2Y2.Addresses.FeeManager[config.chainId]]);
-platformFeeRecipientsRegistry.set("foundation", ["0x67df244584b67e8c51b10ad610aaffa9a402fdb6"]);
-platformFeeRecipientsRegistry.set("infinity", [Sdk.Infinity.Addresses.Exchange[config.chainId]]);
-platformFeeRecipientsRegistry.set("sudoswap", ["0x4e2f98c96e2d595a83afa35888c4af58ac343e44"]);
+
+addPlatformAddress("looks-rare", ["0x5924a28caaf1cc016617874a2f0c3710d881f3c1"]);
+addPlatformAddress("x2y2", [Sdk.X2Y2.Addresses.FeeManager[config.chainId]]);
+addPlatformAddress("foundation", ["0x67df244584b67e8c51b10ad610aaffa9a402fdb6"]);
+addPlatformAddress("infinity", [Sdk.Infinity.Addresses.Exchange[config.chainId]]);
+addPlatformAddress("sudoswap", ["0x4e2f98c96e2d595a83afa35888c4af58ac343e44"]);

--- a/src/sync/events/handlers/royalties/core.ts
+++ b/src/sync/events/handlers/royalties/core.ts
@@ -201,9 +201,9 @@ export async function extractRoyalties(
           !shouldExcludeAddressList.has(address) &&
           !allPlatformFeeRecipients.has(address);
 
-        const notInOtherDef =
-          royaltyRecipients.includes(address) &&
-          !otherRoyaltiesDefinition.find((_) => _.royalties.find((c) => c.recipient === address));
+        const notInOtherDef = !otherRoyaltiesDefinition.find((_) =>
+          _.royalties.find((c) => c.recipient === address)
+        );
 
         if (isEligible && notInOtherDef) {
           curRoyalties.bps = bps;

--- a/src/tests/royalties/router-normalize.test.ts
+++ b/src/tests/royalties/router-normalize.test.ts
@@ -4,6 +4,7 @@ dotEnvConfig();
 import { extractRoyalties } from "@/events-sync/handlers/royalties/core";
 import { getRoyalties } from "@/utils/royalties";
 import { getFillEventsFromTx } from "@/events-sync/handlers/royalties";
+import { StateCache } from "@/events-sync/handlers/royalties";
 
 jest.setTimeout(1000 * 1000);
 
@@ -54,10 +55,14 @@ describe("Royalties - Router normalize", () => {
     });
 
     const { fillEvents } = await getFillEventsFromTx(txHash);
+    const cache: StateCache = {
+      royalties: new Map(),
+    };
+
     for (let index = 0; index < fillEvents.length; index++) {
       const fillEvent = fillEvents[index];
       const feeForPlatform = platformFees.find((_) => _.kind === fillEvent.orderKind);
-      const fees = await extractRoyalties(fillEvent);
+      const fees = await extractRoyalties(fillEvent, cache);
 
       const matched = testCollectionRoyalties.find((c) => c.collection === fillEvent.contract);
 


### PR DESCRIPTION
Based on the whole balance changes, and exclude unrelated payments:
- all related takers and makers from the same tx
- all protocol recipients
- WETH ( deposit and withdraw cause balance change)
- other collection royalty recipients in the same tx (two different collection sales in the same tx and one of the collections don't have the royalties settings)
- threshold= bps > 0 & bps < 30%