### PR TITLE
fix: remove is_reservoir filter from tokens endpoint

### DIFF
--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -424,7 +424,6 @@ export const getTokensV5Options: RouteOptions = {
       sourceConditions.push(`o.fillability_status = 'fillable'`);
       sourceConditions.push(`o.approval_status = 'approved'`);
       sourceConditions.push(`o.source_id_int = $/nativeSource/`);
-      sourceConditions.push(`o.is_reservoir = TRUE`);
       sourceConditions.push(
         `o.taker = '\\x0000000000000000000000000000000000000000' OR o.taker IS NULL`
       );


### PR DESCRIPTION
We were seeing some timeouts with this flag.

An alternative is to look into adding a better index.