### PR TITLE
fix: universe - check approvals correctly

### DIFF
--- a/packages/sdk/src/universe/order.ts
+++ b/packages/sdk/src/universe/order.ts
@@ -252,7 +252,10 @@ export class Order {
         provider
       );
 
-      const isApprovedForAll = await nftContract.isApprovedForAll(this.params.maker);
+      const isApprovedForAll = await nftContract.isApprovedForAll(
+        this.params.maker,
+        Addresses.Exchange[this.chainId]
+      );
 
       if (!isApprovedForAll) {
         const approvedAddress = await nftContract.getApproved(this.params.make.assetType.tokenId);


### PR DESCRIPTION
Universe `checkFillability` fails due to not passing an operator address in the `isApprovedForAll` call