### PR TITLE
fix: unicode in header

### DIFF
--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -189,8 +189,8 @@ export const start = async (): Promise<void> => {
           // Generate the rate limiting header and add them to the request object to be added to the response in the onPreResponse event
           request.headers["X-RateLimit-Limit"] = `${rateLimitRule.points}`;
           request.headers["X-RateLimit-Remaining"] = `${rateLimiterRes.remainingPoints}`;
-          request.headers["X-RateLimit-Reset"] = `${new Date(
-            Date.now() + rateLimiterRes.msBeforeNext
+          request.headers["X-RateLimit-Reset"] = `${Math.round(
+            (Date.now() + rateLimiterRes.msBeforeNext) / 1000
           )}`;
         }
       } catch (error) {


### PR DESCRIPTION
In some cases, `new Date(Date.now()).toString()` will result unicode, which causes http response fail. I recommend using a unix timestamp here to avoid unicode.

```
> new Date(Date.now()).toString()
'Wed Mar 08 2023 18:31:12 GMT+0800 (中国标准时间)'
```