### PR TITLE
fix: leave includeRoyaltiesPaid undefined if token has no last order

### DIFF
--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -1154,7 +1154,10 @@ export const getTokensV5Options: RouteOptions = {
                   feeBreakdown: feeBreakdown,
                 }
               : undefined,
-            royaltiesPaid: query.includeRoyaltiesPaid ? r.royalties_paid : undefined,
+            royaltiesPaid:
+              query.includeRoyaltiesPaid && r.royalties_paid !== null
+                ? r.royalties_paid
+                : undefined,
           },
         };
       });


### PR DESCRIPTION
`r.royalties_paid` can return NULL if there is no matching order ID for the token, so leave `includeRoyaltiesPaid` undefined if there is no order in the first place