### PR TITLE
feat: royalties support more cases

### DIFF
--- a/packages/indexer/src/sync/events/handlers/royalties/config.ts
+++ b/packages/indexer/src/sync/events/handlers/royalties/config.ts
@@ -23,6 +23,12 @@ addPlatformAddress("seaport-v1.4", [
   "0x0000a26b00c1f0df003000390027140000faa719",
 ]);
 
+addPlatformAddress("wyvern-v2", [
+  "0x5b3256965e7c3cf26e11fcaf296dfc8807c01073",
+  "0x8de9c5a032463c561423387a9648c5c7bcc5bc90",
+  "0x0000a26b00c1f0df003000390027140000faa719",
+]);
+
 addPlatformAddress("looks-rare", ["0x5924a28caaf1cc016617874a2f0c3710d881f3c1"]);
 addPlatformAddress("x2y2", [Sdk.X2Y2.Addresses.FeeManager[config.chainId]]);
 addPlatformAddress("foundation", ["0x67df244584b67e8c51b10ad610aaffa9a402fdb6"]);

--- a/packages/indexer/src/sync/events/handlers/royalties/core.ts
+++ b/packages/indexer/src/sync/events/handlers/royalties/core.ts
@@ -291,13 +291,13 @@ export async function extractRoyalties(
         marketplaceFeeBreakdown.push(royalty);
       } else {
         // For different collection with same fee recipient
-        const realtedDetails = sameProtocolDetails.filter((d) => d.recipient === address);
-        const shareSameRecepient = realtedDetails.length === sameProtocolFills.length;
+        const sameRecipientDetails = sameProtocolDetails.filter((d) => d.recipient === address);
+        const shareSameRecipient = sameRecipientDetails.length === sameProtocolFills.length;
 
         let bps: number = bn(balanceChange).mul(10000).div(sameContractTotalPrice).toNumber();
 
-        if (shareSameRecepient) {
-          const configBPS = realtedDetails[0].bps;
+        if (shareSameRecipient) {
+          const configBPS = sameRecipientDetails[0].bps;
           const newBps = bn(balanceChange).mul(10000).div(sameProtocolTotalPrice).toNumber();
           // Make sure the bps is same with the config
           const isValid = configBPS === newBps;
@@ -320,12 +320,12 @@ export async function extractRoyalties(
           _.royalties.find((c) => c.find((d) => d.recipient === address))
         );
 
-        const excludeOtherRecepients = shareSameRecepient ? true : notInOtherDef;
+        const excludeOtherRecipients = shareSameRecipient ? true : notInOtherDef;
         const recipientIsEligible =
           bps > 0 &&
           bps < 1500 &&
           !allPlatformFeeRecipients.has(address) &&
-          excludeOtherRecepients &&
+          excludeOtherRecipients &&
           !notRoyaltyRecipients.has(address);
 
         // For now we exclude AMMs which don't pay royalties

--- a/packages/indexer/src/sync/events/handlers/royalties/core.ts
+++ b/packages/indexer/src/sync/events/handlers/royalties/core.ts
@@ -135,15 +135,31 @@ export async function extractRoyalties(
       // transaction then we try to look for the (sub)call where we
       // find the current fill event's token
       // TODO: What if the same token sold multiple times in different calls?
+      const sameTokenFillEvents = fillEvents.filter(
+        (_) => _.contract === fillEvent.contract && _.tokenId === fillEvent.tokenId
+      );
+
+      const matchExchangeCalls = [];
+
       for (const exchangeCall of exchangeCalls) {
         // Get all payments associated to the call
         const payments = getPayments(exchangeCall);
         const matchingPayment = findMatchingPayment(payments, fillEvent);
         if (matchingPayment) {
-          // If we found a matching payment, then we pin-pointed the (sub)call to analyze
-          subcallToAnalyze = exchangeCall;
-          break;
+          matchExchangeCalls.push(exchangeCall);
         }
+      }
+
+      // If we found a matching payment, then we pin-pointed the (sub)call to analyze
+      if (matchExchangeCalls.length) {
+        const eventIndex = sameTokenFillEvents.findIndex(
+          (_) =>
+            _.contract === fillEvent.contract &&
+            _.tokenId === fillEvent.tokenId &&
+            _.baseEventParams.logIndex === fillEvent.baseEventParams.logIndex
+        );
+
+        subcallToAnalyze = matchExchangeCalls[eventIndex];
       }
     }
   }
@@ -235,6 +251,10 @@ export async function extractRoyalties(
     notRoyaltyRecipients.add(fillEvent.taker);
   });
 
+  const sameContractFillsWithRoyaltyData = fillEventsWithRoyaltyData.filter((c) => {
+    return c.contract != contract;
+  });
+
   // Get the know platform fee recipients for the current fill order kind
   const knownPlatformFeeRecipients = platformFeeRecipientsRegistry.get(fillEvent.orderKind) ?? [];
 
@@ -271,15 +291,19 @@ export async function extractRoyalties(
         marketplaceFeeBreakdown.push(royalty);
       } else {
         // For different collection with same fee recipient
-        const shareSameRecepient =
-          sameProtocolDetails.filter((d) => d.recipient === address).length ===
-          sameProtocolFills.length;
+        const realtedDetails = sameProtocolDetails.filter((d) => d.recipient === address);
+        const shareSameRecepient = realtedDetails.length === sameProtocolFills.length;
 
-        let bps: number;
+        let bps: number = bn(balanceChange).mul(10000).div(sameContractTotalPrice).toNumber();
+
         if (shareSameRecepient) {
-          bps = bn(balanceChange).mul(10000).div(sameProtocolTotalPrice).toNumber();
-        } else {
-          bps = bn(balanceChange).mul(10000).div(sameContractTotalPrice).toNumber();
+          const configBPS = realtedDetails[0].bps;
+          const newBps = bn(balanceChange).mul(10000).div(sameProtocolTotalPrice).toNumber();
+          // Make sure the bps is same with the config
+          const isValid = configBPS === newBps;
+          if (isValid) {
+            bps = newBps;
+          }
         }
 
         if (royaltyRecipients.includes(address)) {
@@ -292,10 +316,16 @@ export async function extractRoyalties(
         // - royalty percentage between 0% and 15% (both exclusive)
         // - royalty recipient is not a known platform fee recipient
         // - royalty recipient is a valid royalty recipient
+        const notInOtherDef = !sameContractFillsWithRoyaltyData.find((_) =>
+          _.royalties.find((c) => c.find((d) => d.recipient === address))
+        );
+
+        const excludeOtherRecepients = shareSameRecepient ? true : notInOtherDef;
         const recipientIsEligible =
           bps > 0 &&
           bps < 1500 &&
           !allPlatformFeeRecipients.has(address) &&
+          excludeOtherRecepients &&
           !notRoyaltyRecipients.has(address);
 
         // For now we exclude AMMs which don't pay royalties

--- a/packages/indexer/src/sync/events/handlers/royalties/index.ts
+++ b/packages/indexer/src/sync/events/handlers/royalties/index.ts
@@ -44,6 +44,7 @@ export type PartialFillEvent = {
   taker: string;
   baseEventParams: {
     txHash: string;
+    logIndex: number;
   };
 };
 
@@ -58,7 +59,8 @@ export const getFillEventsFromTx = async (txHash: string): Promise<PartialFillEv
         fill_events_2.price,
         fill_events_2.amount,
         fill_events_2.maker,
-        fill_events_2.taker
+        fill_events_2.taker,
+        fill_events_2.log_index
       FROM fill_events_2
       WHERE fill_events_2.tx_hash = $/txHash/
     `,
@@ -80,6 +82,7 @@ export const getFillEventsFromTx = async (txHash: string): Promise<PartialFillEv
         taker: fromBuffer(r.taker),
         baseEventParams: {
           txHash,
+          logIndex: r.log_index,
         },
       }))
       // Exclude mints

--- a/packages/indexer/src/tests/royalties/badcase.test.ts
+++ b/packages/indexer/src/tests/royalties/badcase.test.ts
@@ -25,17 +25,12 @@ describe("Royalties", () => {
         collection: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
         data: [
           {
-            recipient: "0xa858ddc0445d8131dac4d1de01f834ffcba52ef1",
             bps: 250,
+            recipient: "0xaae7ac476b117bccafe2f05f582906be44bc8ff1",
           },
-        ],
-      },
-      {
-        collection: "0x60e4d786628fea6478f785a6d7e704777c86a7c6",
-        data: [
           {
-            recipient: "0xa858ddc0445d8131dac4d1de01f834ffcba52ef1",
             bps: 250,
+            recipient: "0xa858ddc0445d8131dac4d1de01f834ffcba52ef1",
           },
         ],
       },
@@ -50,8 +45,8 @@ describe("Royalties", () => {
       {
         contract: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
         tokenId: "5449",
-        royaltyFeeBps: 250,
-        marketplaceFeeBps: 200,
+        royaltyFeeBps: 0,
+        marketplaceFeeBps: 450,
       },
     ];
     await assignRoyaltiesToFillEvents(fillEvents, false, true);
@@ -191,6 +186,263 @@ describe("Royalties", () => {
         contract: "0x60e4d786628fea6478f785a6d7e704777c86a7c6",
         tokenId: "15323",
         royaltyFeeBps: 250,
+        marketplaceFeeBps: 250,
+      },
+    ];
+    await assignRoyaltiesToFillEvents(fillEvents, false, true);
+    for (let index = 0; index < fillEvents.length; index++) {
+      const fillEvent = fillEvents[index];
+      const matchFee = feesList.find(
+        (c) => c.contract === fillEvent.contract && c.tokenId === fillEvent.tokenId
+      );
+      if (matchFee) {
+        expect(fillEvent.royaltyFeeBps).toEqual(matchFee.royaltyFeeBps);
+        expect(fillEvent.marketplaceFeeBps).toEqual(matchFee.marketplaceFeeBps);
+      }
+    }
+  });
+
+  it("erc1155-multiple-sales", async () => {
+    const { fillEvents } = await getFillEventsFromTx(
+      "0x54a3b6a7ab7dd3f9f1df3ad3b0b2e274a40ae991bb5d4378287899e744082c45"
+    );
+
+    const testCollectionRoyalties = [
+      {
+        collection: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+        data: [
+          {
+            recipient: "0xa858ddc0445d8131dac4d1de01f834ffcba52ef1",
+            bps: 250,
+          },
+        ],
+      },
+    ];
+
+    mockGetRoyalties.mockImplementation(async (contract: string) => {
+      const matched = testCollectionRoyalties.find((c) => c.collection === contract);
+      return matched?.data ?? [];
+    });
+
+    const feesList = [
+      {
+        contract: "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        tokenId: "54",
+        royaltyFeeBps: 690,
+        marketplaceFeeBps: 250,
+      },
+    ];
+    await assignRoyaltiesToFillEvents(fillEvents, false, true);
+    for (let index = 0; index < fillEvents.length; index++) {
+      const fillEvent = fillEvents[index];
+      const matchFee = feesList.find(
+        (c) => c.contract === fillEvent.contract && c.tokenId === fillEvent.tokenId
+      );
+      if (matchFee) {
+        expect(fillEvent.royaltyFeeBps).toEqual(matchFee.royaltyFeeBps);
+        expect(fillEvent.marketplaceFeeBps).toEqual(matchFee.marketplaceFeeBps);
+      }
+    }
+  });
+
+  it("multiple-sales-with-wrong", async () => {
+    const { fillEvents } = await getFillEventsFromTx(
+      "0x02d831e6e0f967fbfc0975935c7ed35c328961c39373c0656ea17093106cd760"
+    );
+
+    const testCollectionRoyalties = [
+      {
+        collection: "0x5bd815fd6c096bab38b4c6553cfce3585194dff9",
+        data: [
+          {
+            bps: 500,
+            recipient: "0xdcaae62542aa20e6a8243b2407f18ddb36e83014",
+          },
+        ],
+      },
+      {
+        collection: "0xb32979486938aa9694bfc898f35dbed459f44424",
+        data: [
+          {
+            bps: 1000,
+            recipient: "0x6d4219003714632c88b3f01d8591bee545f33184",
+          },
+        ],
+      },
+      {
+        collection: "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        data: [
+          {
+            bps: 690,
+            recipient: "0x1b1289e34fe05019511d7b436a5138f361904df0",
+          },
+        ],
+      },
+    ];
+
+    mockGetRoyalties.mockImplementation(async (contract: string) => {
+      const matched = testCollectionRoyalties.find((c) => c.collection === contract);
+      return matched?.data ?? [];
+    });
+
+    const feesList = [
+      {
+        contract: "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        tokenId: "8",
+        royaltyFeeBps: 690,
+        marketplaceFeeBps: 250,
+      },
+      {
+        contract: "0xb32979486938aa9694bfc898f35dbed459f44424",
+        tokenId: "10055",
+        royaltyFeeBps: 1000,
+        marketplaceFeeBps: 250,
+      },
+      {
+        contract: "0x5bd815fd6c096bab38b4c6553cfce3585194dff9",
+        tokenId: "13055",
+        royaltyFeeBps: 500,
+        marketplaceFeeBps: 250,
+      },
+    ];
+    await assignRoyaltiesToFillEvents(fillEvents, false, true);
+    for (let index = 0; index < fillEvents.length; index++) {
+      const fillEvent = fillEvents[index];
+      const matchFee = feesList.find(
+        (c) => c.contract === fillEvent.contract && c.tokenId === fillEvent.tokenId
+      );
+      if (matchFee) {
+        expect(fillEvent.royaltyFeeBps).toEqual(matchFee.royaltyFeeBps);
+        expect(fillEvent.marketplaceFeeBps).toEqual(matchFee.marketplaceFeeBps);
+      }
+    }
+  });
+
+  it("multiple-sales-case-1", async () => {
+    const { fillEvents } = await getFillEventsFromTx(
+      "0x67533A3C28F93589B9899E2A822F3658ADF8AA9E754D807FBA0E80A46CA0C7D4"
+    );
+
+    const testCollectionRoyalties = [
+      {
+        collection: "0x5bd815fd6c096bab38b4c6553cfce3585194dff9",
+        data: [
+          {
+            bps: 500,
+            recipient: "0xdcaae62542aa20e6a8243b2407f18ddb36e83014",
+          },
+        ],
+      },
+      {
+        collection: "0xb32979486938aa9694bfc898f35dbed459f44424",
+        data: [
+          {
+            bps: 1000,
+            recipient: "0x6d4219003714632c88b3f01d8591bee545f33184",
+          },
+        ],
+      },
+      {
+        collection: "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        data: [
+          {
+            bps: 690,
+            recipient: "0x1b1289e34fe05019511d7b436a5138f361904df0",
+          },
+        ],
+      },
+    ];
+
+    mockGetRoyalties.mockImplementation(async (contract: string) => {
+      const matched = testCollectionRoyalties.find((c) => c.collection === contract);
+      return matched?.data ?? [];
+    });
+
+    const feesList = [
+      {
+        contract: "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        tokenId: "8",
+        royaltyFeeBps: 690,
+        marketplaceFeeBps: 250,
+      },
+      {
+        contract: "0xb32979486938aa9694bfc898f35dbed459f44424",
+        tokenId: "10055",
+        royaltyFeeBps: 1000,
+        marketplaceFeeBps: 250,
+      },
+      {
+        contract: "0x5bd815fd6c096bab38b4c6553cfce3585194dff9",
+        tokenId: "13055",
+        royaltyFeeBps: 500,
+        marketplaceFeeBps: 250,
+      },
+    ];
+    await assignRoyaltiesToFillEvents(fillEvents, false, true);
+    for (let index = 0; index < fillEvents.length; index++) {
+      const fillEvent = fillEvents[index];
+      const matchFee = feesList.find(
+        (c) => c.contract === fillEvent.contract && c.tokenId === fillEvent.tokenId
+      );
+      if (matchFee) {
+        expect(fillEvent.royaltyFeeBps).toEqual(matchFee.royaltyFeeBps);
+        expect(fillEvent.marketplaceFeeBps).toEqual(matchFee.marketplaceFeeBps);
+      }
+    }
+  });
+
+  it("multiple-sales-case-2", async () => {
+    const { fillEvents } = await getFillEventsFromTx(
+      "0x97d65878fafc3e5ffe4ce1e288125bb84b4734004dc7d8575d4163fb13457a8d"
+    );
+
+    const testCollectionRoyalties = [
+      {
+        collection: "0xba30e5f9bb24caa003e9f2f0497ad287fdf95623",
+        data: [
+          {
+            bps: 250,
+            recipient: "0xa858ddc0445d8131dac4d1de01f834ffcba52ef1",
+          },
+        ],
+      },
+      {
+        collection: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+        data: [
+          {
+            bps: 250,
+            recipient: "0xa858ddc0445d8131dac4d1de01f834ffcba52ef1",
+          },
+          {
+            bps: 250,
+            recipient: "0xaae7ac476b117bccafe2f05f582906be44bc8ff1",
+          },
+        ],
+      },
+    ];
+
+    mockGetRoyalties.mockImplementation(async (contract: string) => {
+      const matched = testCollectionRoyalties.find((c) => c.collection === contract);
+      return matched?.data ?? [];
+    });
+
+    const feesList = [
+      {
+        contract: "0xba30e5f9bb24caa003e9f2f0497ad287fdf95623",
+        tokenId: "8272",
+        royaltyFeeBps: 0,
+        marketplaceFeeBps: 250,
+      },
+      {
+        contract: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+        tokenId: "5300",
+        royaltyFeeBps: 250,
+        marketplaceFeeBps: 250,
+      },
+      {
+        contract: "0x5bd815fd6c096bab38b4c6553cfce3585194dff9",
+        tokenId: "13055",
+        royaltyFeeBps: 500,
         marketplaceFeeBps: 250,
       },
     ];


### PR DESCRIPTION
- for ERC1155, match exchange-call needs to be based on log-index
- use the bps from config as the valid bps
- exclude other collection recepients