### PR TITLE
fix: add back NULLS LAST and recreate index to use NULLS LAST too

### DIFF
--- a/packages/indexer/src/migrations/1652729912828_activities.sql
+++ b/packages/indexer/src/migrations/1652729912828_activities.sql
@@ -37,7 +37,7 @@ CREATE UNIQUE INDEX activities_hash_unique_index
     ON activities (hash);
 
 CREATE INDEX activities_event_timestamp_index
-  ON activities (event_timestamp DESC);
+  ON activities (event_timestamp DESC NULLS LAST);
 
 -- Down Migration
 

--- a/packages/indexer/src/models/activities/index.ts
+++ b/packages/indexer/src/models/activities/index.ts
@@ -275,6 +275,7 @@ export class Activities {
     let typesFilter = "";
     let metadataQuery = "";
     let collectionFilter = "";
+    let nullsLast = "";
 
     if (!_.isNull(createdBefore)) {
       continuation = `AND activities.${sortByColumn} < $/createdBefore/`;
@@ -285,6 +286,7 @@ export class Activities {
     }
 
     if (collectionsSetId) {
+      nullsLast = "NULLS LAST";
       collectionFilter = `WHERE activities.collection_id IN (select collection_id
             FROM collections_sets_collections
             WHERE collections_set_id = $/collectionsSetId/
@@ -293,6 +295,7 @@ export class Activities {
       collectionFilter =
         "WHERE activities.collection_id IN (SELECT id FROM collections WHERE community = $/community/)";
     } else if (collectionId) {
+      nullsLast = "NULLS LAST";
       collectionFilter = "WHERE activities.collection_id = $/collectionId/";
     }
 
@@ -444,7 +447,7 @@ export class Activities {
              ${collectionFilter}
              ${continuation}
              ${typesFilter}
-             ORDER BY activities.${sortByColumn} DESC
+             ORDER BY activities.${sortByColumn} DESC ${nullsLast}
              LIMIT $/limit/`,
       {
         collectionId,


### PR DESCRIPTION
- renamed existing `activities_event_timestamp_index` to `activities_event_timestamp_old_index`
- created new `activities_event_timestamp_index` on mainnet, goerli, and polygon with:
```
CREATE INDEX CONCURRENTLY activities_event_timestamp_index ON activities (event_timestamp DESC NULLS LAST);
``` 

- after this is merged, will confirm no slowness across any previously reported timeouts on the endpoint and then DROP `activities_event_timestamp_old_index`