### PR TITLE
fix: sort by nulls last when community is given

### DIFF
--- a/packages/indexer/src/models/activities/index.ts
+++ b/packages/indexer/src/models/activities/index.ts
@@ -284,7 +284,6 @@ export class Activities {
     let metadataQuery = "";
     let metadataOrderQuery = "";
     let collectionFilter = "";
-    let nullsLast = "";
 
     if (!_.isNull(createdBefore)) {
       continuation = `AND activities.${sortByColumn} < $/createdBefore/`;
@@ -295,7 +294,6 @@ export class Activities {
     }
 
     if (collectionsSetId) {
-      nullsLast = "NULLS LAST";
       collectionFilter = `WHERE activities.collection_id IN (select collection_id
             FROM collections_sets_collections
             WHERE collections_set_id = $/collectionsSetId/
@@ -304,7 +302,6 @@ export class Activities {
       collectionFilter =
         "WHERE activities.collection_id IN (SELECT id FROM collections WHERE community = $/community/)";
     } else if (collectionId) {
-      nullsLast = "NULLS LAST";
       collectionFilter = "WHERE activities.collection_id = $/collectionId/";
     }
 
@@ -462,7 +459,7 @@ export class Activities {
              ${collectionFilter}
              ${continuation}
              ${typesFilter}
-             ORDER BY activities.${sortByColumn} DESC ${nullsLast}
+             ORDER BY activities.${sortByColumn} DESC NULLS LAST
              LIMIT $/limit/`,
       {
         collectionId,


### PR DESCRIPTION
we use nulls last in every case except when community is given, we should be using it everywhere now that the index has been updated