### PR TITLE
deor/platf 969 updating 1day volume values for

### DIFF
--- a/packages/indexer/src/models/daily-volumes/daily-volume.ts
+++ b/packages/indexer/src/models/daily-volumes/daily-volume.ts
@@ -230,6 +230,14 @@ export class DailyVolume {
     const currentDate = new Date();
     const startTime = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000).getTime() / 1000;
 
+    // Get a list of all collections that have non-null 1day values
+    const collectionsWith1DayValues = await ridb.manyOrNone(
+      `SELECT id FROM collections WHERE day1_volume IS NOT NULL ${
+        collectionId ? "AND id = $/collectionId/" : ""
+      }`,
+      { collectionId }
+    );
+
     const results = await ridb.manyOrNone(
       `SELECT t1.collection_id,
             t1.volume,
@@ -298,6 +306,40 @@ export class DailyVolume {
         logger.error(
           "daily-volumes",
           `Error while inserting/updating daily volumes. collectionId=${collectionId}`
+        );
+
+        return false;
+      }
+    }
+
+    const updatedCollectionIds = results.map((r: any) => r.collection_id);
+    const collectionsToUpdateToNull = collectionsWith1DayValues.filter(
+      (c: any) => !updatedCollectionIds.includes(c.id)
+    );
+
+    if (collectionsToUpdateToNull.length) {
+      const updateToNullQueries = collectionsToUpdateToNull.map((c: any) => {
+        return {
+          query: `
+          UPDATE collections
+          SET
+            day1_volume = NULL,
+            day1_rank = NULL,
+            day1_floor_sell_value = NULL,
+            day1_volume_change = NULL
+          WHERE id = $/collection_id/
+        `,
+          values: { collection_id: c.id },
+        };
+      });
+
+      try {
+        const concat = pgp.helpers.concat(updateToNullQueries);
+        await idb.none(concat);
+      } catch (error: any) {
+        logger.error(
+          "daily-volumes",
+          `Error while setting 1day values to null. collectionId=${collectionId}`
         );
 
         return false;

--- a/packages/indexer/src/models/daily-volumes/daily-volume.ts
+++ b/packages/indexer/src/models/daily-volumes/daily-volume.ts
@@ -230,6 +230,14 @@ export class DailyVolume {
     const currentDate = new Date();
     const startTime = new Date(currentDate.getTime() - 24 * 60 * 60 * 1000).getTime() / 1000;
 
+    // Get a list of all collections that have non-null 1day values
+    const collectionsWith1DayValues = await ridb.manyOrNone(
+      `SELECT id FROM collections WHERE day1_volume IS NOT NULL ${
+        collectionId ? "AND id = $/collectionId/" : ""
+      }`,
+      { collectionId }
+    );
+
     const results = await ridb.manyOrNone(
       `SELECT t1.collection_id,
             t1.volume,
@@ -304,62 +312,38 @@ export class DailyVolume {
       }
     }
 
-    try {
-      await ridb.none(
-        `
-        UPDATE collections
-        SET
-          day1_volume = 0,
-          day1_rank = NULL,
-          day1_floor_sell_value = NULL,
-          day1_volume_change = NULL
-        WHERE id NOT IN (
-          SELECT collection_id
-          FROM (
-            SELECT t1.collection_id
-            FROM
-              (SELECT
-                t.contract,
-                "collection_id",
-                sum("fe"."price") AS "volume",
-                RANK() OVER (ORDER BY SUM(price) DESC, "collection_id") "rank",
-                min(fe.price) AS "floor_sell_value",
-                (
-                    SELECT sum("fe"."price") / (SELECT 
-                          sum("fe2"."price") 
-                          FROM fill_events_2 fe2 
-                        WHERE t.contract = fe2.contract AND
-                              fe2.price > 0
-                          AND "fe2"."timestamp" < $/yesterdayTimestamp/
-                          AND "fe2".timestamp >= $/endYesterdayTimestamp/
-                      )
-                ) as "volume_change"
+    const updatedCollectionIds = results.map((r: any) => r.collection_id);
+    const collectionsToUpdateToNull = collectionsWith1DayValues.filter(
+      (c: any) => !updatedCollectionIds.includes(c.id)
+    );
 
-              FROM "fill_events_2" "fe"
-                JOIN "tokens" "t" ON "fe"."token_id" = "t"."token_id" AND "fe"."contract" = "t"."contract"
-                JOIN "collections" "c" ON "t"."collection_id" = "c"."id"
-              WHERE
-                "fe"."timestamp" >= $/yesterdayTimestamp/
-                AND fe.price > 0
-                AND fe.is_primary IS NOT TRUE
-                AND coalesce(fe.wash_trading_score, 0) = 0
-                ${collectionId ? "AND collection_id = $/collectionId/" : ""}
-              GROUP BY t.contract, "collection_id") t1
-          ) t2
-        )
-    `,
-        {
-          yesterdayTimestamp: startTime,
-          endYesterdayTimestamp: startTime - 24 * 60 * 60,
+    if (collectionsToUpdateToNull.length) {
+      const updateToNullQueries = collectionsToUpdateToNull.map((c: any) => {
+        return {
+          query: `
+          UPDATE collections
+          SET
+            day1_volume = 0,
+            day1_rank = NULL,
+            day1_floor_sell_value = NULL,
+            day1_volume_change = NULL
+          WHERE id = $/collection_id/
+        `,
+          values: { collection_id: c.id },
+        };
+      });
 
-          collectionId,
-        }
-      );
-    } catch (error: any) {
-      logger.error(
-        "daily-volumes",
-        `Error while inserting/updating daily volumes. collectionId=${collectionId}`
-      );
+      try {
+        const concat = pgp.helpers.concat(updateToNullQueries);
+        await idb.none(concat);
+      } catch (error: any) {
+        logger.error(
+          "daily-volumes",
+          `Error while setting 1day values to null. collectionId=${collectionId}`
+        );
+
+        return false;
+      }
     }
 
     return true;


### PR DESCRIPTION
- fix: update job id for recalculate old collection token count
- fix: use default jobId if recalculating for old collection
- fix: update apis tags
- fix: automate indexer-worker-polygon deployment
- fix: api tag
- fix: api description
- feat: update 1day volume to handle collections with no sales in 24h
- feat: change from multipe queries to one query for updating values
- fix: revert to prev method
