### PR TITLE
feat: put common seaport orderbook code to base

### DIFF
--- a/packages/indexer/src/jobs/arweave-relay/index.ts
+++ b/packages/indexer/src/jobs/arweave-relay/index.ts
@@ -13,7 +13,7 @@ const PENDING_DATA_KEY = "pending-arweave-data";
 
 export const addPendingOrdersSeaport = async (
   data: {
-    order: Sdk.SeaportV11.Order;
+    order: Sdk.SeaportBase.IOrder;
     schemaHash?: string;
     source?: string;
   }[]
@@ -23,30 +23,7 @@ export const addPendingOrdersSeaport = async (
       PENDING_DATA_KEY,
       ...data.map(({ order, schemaHash }) =>
         JSON.stringify({
-          kind: "seaport",
-          data: {
-            ...order.params,
-            schemaHash,
-          },
-        })
-      )
-    );
-  }
-};
-
-export const addPendingOrdersSeaportV14 = async (
-  data: {
-    order: Sdk.SeaportV14.Order;
-    schemaHash?: string;
-    source?: string;
-  }[]
-) => {
-  if (config.arweaveRelayerKey && data.length) {
-    await redis.rpush(
-      PENDING_DATA_KEY,
-      ...data.map(({ order, schemaHash }) =>
-        JSON.stringify({
-          kind: "seaport-v1.4",
+          kind: order.getKind(),
           data: {
             ...order.params,
             schemaHash,

--- a/packages/indexer/src/orderbook/orders/seaport-base/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-base/build/buy/token.ts
@@ -1,0 +1,65 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { redb } from "@/common/db";
+import { toBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { BaseOrderBuildOptions, OrderBuildInfo } from "../utils";
+
+export interface BuildOrderOptions extends BaseOrderBuildOptions {
+  contract: string;
+  tokenId: string;
+}
+
+export class BuyTokenBuilderBase {
+  private getBuildInfoFunc: (
+    options: BaseOrderBuildOptions,
+    collection: string,
+    side: "sell" | "buy"
+  ) => Promise<OrderBuildInfo>;
+
+  constructor(
+    getBuildInfoFunc: (
+      options: BaseOrderBuildOptions,
+      collection: string,
+      side: "sell" | "buy"
+    ) => Promise<OrderBuildInfo>
+  ) {
+    this.getBuildInfoFunc = getBuildInfoFunc;
+  }
+
+  public async build<T extends Sdk.SeaportBase.IOrder>(
+    options: BuildOrderOptions,
+    orderBuilder: { new (chainId: number, params: Sdk.SeaportBase.Types.OrderComponents): T }
+  ): Promise<T> {
+    const excludeFlaggedTokens = options.excludeFlaggedTokens
+      ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
+      : "";
+
+    const collectionResult = await redb.oneOrNone(
+      `
+            SELECT
+              tokens.collection_id
+            FROM tokens
+            WHERE tokens.contract = $/contract/
+            AND tokens.token_id = $/tokenId/
+            ${excludeFlaggedTokens}
+          `,
+      {
+        contract: toBuffer(options.contract),
+        tokenId: options.tokenId,
+      }
+    );
+    if (!collectionResult) {
+      throw new Error("Could not retrieve token's collection");
+    }
+
+    const buildInfo = await this.getBuildInfoFunc(options, collectionResult.collection_id, "buy");
+
+    const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
+
+    const tokenId = options.tokenId;
+    const amount = options.quantity;
+
+    return builder?.build({ ...buildInfo.params, tokenId, amount }, orderBuilder);
+  }
+}

--- a/packages/indexer/src/orderbook/orders/seaport-base/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-base/build/sell/token.ts
@@ -1,0 +1,58 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { redb } from "@/common/db";
+import { toBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { BaseOrderBuildOptions, OrderBuildInfo } from "../utils";
+
+export interface BuildOrderOptions extends BaseOrderBuildOptions {
+  tokenId: string;
+}
+
+export class SellTokenBuilderBase {
+  private getBuildInfoFunc: (
+    options: BaseOrderBuildOptions,
+    collection: string,
+    side: "sell" | "buy"
+  ) => Promise<OrderBuildInfo>;
+
+  constructor(
+    getBuildInfoFunc: (
+      options: BaseOrderBuildOptions,
+      collection: string,
+      side: "sell" | "buy"
+    ) => Promise<OrderBuildInfo>
+  ) {
+    this.getBuildInfoFunc = getBuildInfoFunc;
+  }
+
+  public async build<T extends Sdk.SeaportBase.IOrder>(
+    options: BuildOrderOptions,
+    orderBuilder: { new (chainId: number, params: Sdk.SeaportBase.Types.OrderComponents): T }
+  ): Promise<T> {
+    const collectionResult = await redb.oneOrNone(
+      `
+              SELECT
+                tokens.collection_id
+              FROM tokens
+              WHERE tokens.contract = $/contract/
+                AND tokens.token_id = $/tokenId/
+            `,
+      {
+        contract: toBuffer(options.contract!),
+        tokenId: options.tokenId,
+      }
+    );
+    if (!collectionResult) {
+      throw new Error("Could not retrieve token's collection");
+    }
+
+    const buildInfo = await this.getBuildInfoFunc(options, collectionResult.collection_id, "sell");
+
+    const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
+
+    const tokenId = options.tokenId;
+
+    return builder?.build({ ...buildInfo.params, tokenId }, orderBuilder);
+  }
+}

--- a/packages/indexer/src/orderbook/orders/seaport-base/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-base/build/utils.ts
@@ -1,0 +1,37 @@
+import * as Sdk from "@reservoir0x/sdk";
+import { generateSourceBytes } from "@reservoir0x/sdk/dist/utils";
+
+import { bn } from "@/common/utils";
+
+export interface BaseOrderBuildOptions {
+  maker: string;
+  contract?: string;
+  weiPrice: string;
+  orderbook: "opensea" | "reservoir";
+  useOffChainCancellation?: boolean;
+  replaceOrderId?: string;
+  orderType?: Sdk.SeaportBase.Types.OrderType;
+  currency?: string;
+  quantity?: number;
+  nonce?: string;
+  fee?: number[];
+  feeRecipient?: string[];
+  listingTime?: number;
+  expirationTime?: number;
+  salt?: string;
+  automatedRoyalties?: boolean;
+  royaltyBps?: number;
+  excludeFlaggedTokens?: boolean;
+  source?: string;
+}
+
+export type OrderBuildInfo = {
+  params: Sdk.SeaportBase.BaseBuildParams;
+  kind: "erc721" | "erc1155";
+};
+
+export const padSourceToSalt = (source: string, salt: string) => {
+  const sourceHash = generateSourceBytes(source);
+  const saltHex = bn(salt)._hex.slice(6);
+  return bn(`0x${sourceHash}${saltHex}`).toString();
+};

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/attribute.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/attribute.ts
@@ -3,9 +3,10 @@ import * as Sdk from "@reservoir0x/sdk";
 import { redb } from "@/common/db";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
+import { getBuildInfo } from "../utils";
+import { BaseOrderBuildOptions } from "../../../seaport-base/build/utils";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   // TODO: refactor
   // The following combinations are possible:
   // - collection + attributes
@@ -51,7 +52,7 @@ export const build = async (options: BuildOrderOptions) => {
       throw new Error("Attribute has too many items");
     }
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(attributeResult.contract),
@@ -108,7 +109,7 @@ export const build = async (options: BuildOrderOptions) => {
       }
     );
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(tokens[0].contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/collection.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/collection.ts
@@ -5,12 +5,13 @@ import { idb } from "@/common/db";
 import { redis } from "@/common/redis";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
+import { BaseOrderBuildOptions } from "../../../seaport-base/build/utils";
+import { getBuildInfo } from "../utils";
 import { generateSchemaHash } from "@/orderbook/orders/utils";
 import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
 import { Tokens } from "@/models/tokens";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   collection: string;
 }
 
@@ -36,7 +37,7 @@ export const build = async (options: BuildOrderOptions) => {
     throw new Error("Collection has too many tokens");
   }
 
-  const buildInfo = await utils.getBuildInfo(
+  const buildInfo = await getBuildInfo(
     {
       ...options,
       contract: fromBuffer(collectionResult.contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/token.ts
@@ -1,44 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  contract: string;
-  tokenId: string;
-}
+import { getBuildInfo } from "../utils";
+import {
+  BuyTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/buy/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const excludeFlaggedTokens = options.excludeFlaggedTokens
-    ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
-    : "";
-
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-      AND tokens.token_id = $/tokenId/
-      ${excludeFlaggedTokens}
-    `,
-    {
-      contract: toBuffer(options.contract),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "buy");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  return builder?.build(
-    { ...buildInfo.params, tokenId: options.tokenId, amount: options.quantity },
-    Sdk.SeaportV11.Order
-  );
+  const builder = new BuyTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV11.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/sell/token.ts
@@ -1,37 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  tokenId: string;
-}
+import { getBuildInfo } from "../utils";
+import {
+  SellTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/sell/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-        AND tokens.token_id = $/tokenId/
-    `,
-    {
-      contract: toBuffer(options.contract!),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "sell");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  const tokenId = options.tokenId;
-
-  return builder?.build({ ...buildInfo.params, tokenId }, Sdk.SeaportV11.Order);
+  const builder = new SellTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV11.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/utils.ts
@@ -1,6 +1,6 @@
 import { AddressZero } from "@ethersproject/constants";
 import * as Sdk from "@reservoir0x/sdk";
-import { generateSourceBytes, getRandomBytes } from "@reservoir0x/sdk/dist/utils";
+import { getRandomBytes } from "@reservoir0x/sdk/dist/utils";
 
 import { redb } from "@/common/db";
 import { baseProvider } from "@/common/provider";
@@ -8,37 +8,11 @@ import { bn, fromBuffer, now } from "@/common/utils";
 import { config } from "@/config/index";
 import * as marketplaceFees from "@/utils/marketplace-fees";
 import { logger } from "@/common/logger";
-
-export interface BaseOrderBuildOptions {
-  maker: string;
-  contract?: string;
-  weiPrice: string;
-  orderbook: "opensea" | "reservoir";
-  orderType?: Sdk.SeaportBase.Types.OrderType;
-  currency?: string;
-  quantity?: number;
-  nonce?: string;
-  fee?: number[];
-  feeRecipient?: string[];
-  listingTime?: number;
-  expirationTime?: number;
-  salt?: string;
-  automatedRoyalties?: boolean;
-  royaltyBps?: number;
-  excludeFlaggedTokens?: boolean;
-  source?: string;
-}
-
-type OrderBuildInfo = {
-  params: Sdk.SeaportBase.BaseBuildParams;
-  kind: "erc721" | "erc1155";
-};
-
-export const padSourceToSalt = (source: string, salt: string) => {
-  const sourceHash = generateSourceBytes(source);
-  const saltHex = bn(salt)._hex.slice(6);
-  return bn(`0x${sourceHash}${saltHex}`).toString();
-};
+import {
+  BaseOrderBuildOptions,
+  OrderBuildInfo,
+  padSourceToSalt,
+} from "../../seaport-base/build/utils";
 
 export const getBuildInfo = async (
   options: BaseOrderBuildOptions,

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/attribute.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/attribute.ts
@@ -4,10 +4,11 @@ import { BigNumberish } from "@ethersproject/bignumber";
 import { redb } from "@/common/db";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
+import { getBuildInfo } from "../utils";
+import { BaseOrderBuildOptions } from "../../../seaport-base/build/utils";
 import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   // TODO: refactor
   // The following combinations are possible:
   // - collection + attributes
@@ -56,7 +57,7 @@ export const build = async (options: BuildOrderOptions) => {
       throw new Error("Attribute has too many items");
     }
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(attributeResult.contract),
@@ -129,7 +130,7 @@ export const build = async (options: BuildOrderOptions) => {
       }
     );
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(tokens[0].contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/collection.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/collection.ts
@@ -5,12 +5,13 @@ import { idb } from "@/common/db";
 import { redis } from "@/common/redis";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
+import { getBuildInfo } from "../utils";
+import { BaseOrderBuildOptions } from "../../../seaport-base/build/utils";
 import { generateSchemaHash } from "@/orderbook/orders/utils";
 import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
 import { Tokens } from "@/models/tokens";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   collection: string;
 }
 
@@ -36,7 +37,7 @@ export const build = async (options: BuildOrderOptions) => {
     throw new Error("Collection has too many tokens");
   }
 
-  const buildInfo = await utils.getBuildInfo(
+  const buildInfo = await getBuildInfo(
     {
       ...options,
       contract: fromBuffer(collectionResult.contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/token.ts
@@ -1,44 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  contract: string;
-  tokenId: string;
-}
+import { getBuildInfo } from "../utils";
+import {
+  BuyTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/buy/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const excludeFlaggedTokens = options.excludeFlaggedTokens
-    ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
-    : "";
-
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-      AND tokens.token_id = $/tokenId/
-      ${excludeFlaggedTokens}
-    `,
-    {
-      contract: toBuffer(options.contract),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "buy");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  const tokenId = options.tokenId;
-  const amount = options.quantity;
-
-  return builder?.build({ ...buildInfo.params, tokenId, amount }, Sdk.SeaportV14.Order);
+  const builder = new BuyTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV14.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/sell/token.ts
@@ -1,37 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  tokenId: string;
-}
+import { getBuildInfo } from "../utils";
+import {
+  SellTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/sell/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-        AND tokens.token_id = $/tokenId/
-    `,
-    {
-      contract: toBuffer(options.contract!),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "sell");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  const tokenId = options.tokenId;
-
-  return builder?.build({ ...buildInfo.params, tokenId }, Sdk.SeaportV14.Order);
+  const builder = new SellTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV14.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/utils.ts
@@ -1,6 +1,6 @@
 import { AddressZero } from "@ethersproject/constants";
 import * as Sdk from "@reservoir0x/sdk";
-import { generateSourceBytes, getRandomBytes } from "@reservoir0x/sdk/dist/utils";
+import { getRandomBytes } from "@reservoir0x/sdk/dist/utils";
 
 import { redb } from "@/common/db";
 import { baseProvider } from "@/common/provider";
@@ -8,39 +8,11 @@ import { bn, fromBuffer, now } from "@/common/utils";
 import { config } from "@/config/index";
 import { logger } from "@/common/logger";
 import * as marketplaceFees from "@/utils/marketplace-fees";
-
-export interface BaseOrderBuildOptions {
-  maker: string;
-  contract?: string;
-  weiPrice: string;
-  orderbook: "opensea" | "reservoir";
-  useOffChainCancellation?: boolean;
-  replaceOrderId?: string;
-  orderType?: Sdk.SeaportBase.Types.OrderType;
-  currency?: string;
-  quantity?: number;
-  nonce?: string;
-  fee?: number[];
-  feeRecipient?: string[];
-  listingTime?: number;
-  expirationTime?: number;
-  salt?: string;
-  automatedRoyalties?: boolean;
-  royaltyBps?: number;
-  excludeFlaggedTokens?: boolean;
-  source?: string;
-}
-
-type OrderBuildInfo = {
-  params: Sdk.SeaportBase.BaseBuildParams;
-  kind: "erc721" | "erc1155";
-};
-
-export const padSourceToSalt = (source: string, salt: string) => {
-  const sourceHash = generateSourceBytes(source);
-  const saltHex = bn(salt)._hex.slice(6);
-  return bn(`0x${sourceHash}${saltHex}`).toString();
-};
+import {
+  BaseOrderBuildOptions,
+  OrderBuildInfo,
+  padSourceToSalt,
+} from "../../seaport-base/build/utils";
 
 export const getBuildInfo = async (
   options: BaseOrderBuildOptions,

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/index.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/index.ts
@@ -1285,7 +1285,7 @@ export const save = async (
     );
 
     if (relayToArweave) {
-      await arweaveRelay.addPendingOrdersSeaportV14(arweaveData);
+      await arweaveRelay.addPendingOrdersSeaport(arweaveData);
     }
   }
 


### PR DESCRIPTION
This pull request tries to remove duplicate code in `orderbook/orders/seaport-v1.1` and `orderbook/orders/seaport-v1.4`

`buy/token.ts` and `sell/token.ts` are almost the same, so I put them to `seaport-base`
