### PR TITLE
fix: improve gettokens perf with nativeSource

### DIFF
--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -422,7 +422,7 @@ export const getTokensV5Options: RouteOptions = {
       LEFT JOIN LATERAL (
         SELECT
           CASE WHEN f.royalty_fee_breakdown IS NOT NULL THEN true
-          WHEN o.fee_breakdown IS NULL THEN false 
+          WHEN o.fee_breakdown IS NULL THEN false
           WHEN 'royalty' IN (SELECT jsonb_array_elements(o.fee_breakdown)->>'kind') THEN true
           ELSE false END AS royalties_paid
         FROM fill_events_2 f
@@ -462,6 +462,13 @@ export const getTokensV5Options: RouteOptions = {
       if (query.currencies) {
         sourceConditions.push(`o.currency IN ($/currenciesFilter:raw/)`);
       }
+
+      sourceConditions.push(`
+        tst.token_id IN (
+          SELECT token_id FROM orders
+          WHERE ${sourceConditions.join(" AND ")}
+        )
+      `);
 
       if (query.contract) {
         sourceConditions.push(`tst.contract = $/contract/`);
@@ -508,7 +515,7 @@ export const getTokensV5Options: RouteOptions = {
           ORDER BY token_id, contract, ${
             query.normalizeRoyalties ? "o.normalized_value" : "o.value"
           }
-        ) s ON s.contract = t.contract AND s.token_id = t.token_id      
+        ) s ON s.contract = t.contract AND s.token_id = t.token_id
       `;
     }
 

--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
@@ -416,10 +416,10 @@ export const getTokensV6Options: RouteOptions = {
       includeRoyaltyBreakdownQuery = `
         LEFT JOIN LATERAL (
         SELECT
-          fe.timestamp AS last_sale_timestamp,          
+          fe.timestamp AS last_sale_timestamp,
           fe.currency AS last_sale_currency,
-          fe.currency_price AS last_sale_currency_price,            
-          fe.price AS last_sale_price,    
+          fe.currency_price AS last_sale_currency_price,
+          fe.price AS last_sale_price,
           fe.usd_price AS last_sale_usd_price,
           fe.marketplace_fee_bps AS last_sale_marketplace_fee_bps,
           fe.royalty_fee_bps AS last_sale_royalty_fee_bps,
@@ -462,6 +462,13 @@ export const getTokensV6Options: RouteOptions = {
       if (query.currencies) {
         sourceConditions.push(`o.currency IN ($/currenciesFilter:raw/)`);
       }
+
+      sourceConditions.push(`
+        tst.token_id IN (
+          SELECT token_id FROM orders
+          WHERE ${sourceConditions.join(" AND ")}
+        )
+      `);
 
       if (query.contract) {
         sourceConditions.push(`tst.contract = $/contract/`);
@@ -508,7 +515,7 @@ export const getTokensV6Options: RouteOptions = {
           ORDER BY token_id, contract, ${
             query.normalizeRoyalties ? "o.normalized_value" : "o.value"
           }
-        ) s ON s.contract = t.contract AND s.token_id = t.token_id      
+        ) s ON s.contract = t.contract AND s.token_id = t.token_id
       `;
     }
 


### PR DESCRIPTION
The modified query includes a subquery in the WHERE clause that filters tst.token_id. This subquery retrieves the list of token_id values from the orders table that meet the specified conditions (sell side, fillable, approved, source_id_int, and taker criteria). The main query then filters tst.token_id based on the results of this subquery.

The reason why this modification might lead to improved performance is that it narrows down the set of token_id values that need to be considered during the join between the orders table and the token_sets_tokens table. By filtering the tst.token_id based on the subquery, the query planner can potentially eliminate a large number of unnecessary rows before executing the join operation. 