### PR TITLE
d3or/add tags to websocket events

### DIFF
--- a/packages/indexer/src/jobs/websocket-events/events/new-sell-order-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-sell-order-websocket-event.ts
@@ -124,9 +124,17 @@ export class NewSellOrderWebsocketEvent {
       };
 
       redisWebsocketPublisher.publish(
-        "asks",
+        "events",
         JSON.stringify({
           event: "ask.created",
+          tags: {
+            collectionId: rawResult.contract,
+            token_set_id: rawResult.token_set_id,
+            tokenId: rawResult.token_set_id.split(":")[2],
+            kind: rawResult.kind,
+            side: rawResult.side,
+            source: source?.getTitle(),
+          },
           data: result,
         })
       );

--- a/packages/indexer/src/jobs/websocket-events/events/new-sell-order-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-sell-order-websocket-event.ts
@@ -128,12 +128,7 @@ export class NewSellOrderWebsocketEvent {
         JSON.stringify({
           event: "ask.created",
           tags: {
-            collectionId: rawResult.contract,
-            tokenSetId: rawResult.token_set_id,
-            tokenId: rawResult.token_set_id.split(":")[2],
-            kind: rawResult.kind,
-            side: rawResult.side,
-            source: source?.getTitle(),
+            contract: fromBuffer(rawResult.contract),
           },
           data: result,
         })

--- a/packages/indexer/src/jobs/websocket-events/events/new-sell-order-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-sell-order-websocket-event.ts
@@ -129,7 +129,7 @@ export class NewSellOrderWebsocketEvent {
           event: "ask.created",
           tags: {
             collectionId: rawResult.contract,
-            token_set_id: rawResult.token_set_id,
+            tokenSetId: rawResult.token_set_id,
             tokenId: rawResult.token_set_id.split(":")[2],
             kind: rawResult.kind,
             side: rawResult.side,

--- a/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
@@ -153,10 +153,6 @@ export class NewTopBidWebsocketEvent {
               event: "top-bid.changed",
               tags: {
                 collectionId: order.collection_id,
-                collectionSlug: order.collection_slug,
-                tokenSetId: order.token_set_id,
-                tokenId: order.token_set_id.split(":")[2],
-                maker: order.maker,
               },
               data: payload,
             })

--- a/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
@@ -23,6 +23,7 @@ export class NewTopBidWebsocketEvent {
                 orders.maker,
                 orders.price,
                 orders.value,
+                orders.contract,
                 orders.currency_value,
                 orders.currency_price,
                 orders.currency,
@@ -108,6 +109,7 @@ export class NewTopBidWebsocketEvent {
       payloads.push({
         order: {
           id: order.id,
+          contract: fromBuffer(order.contract),
           maker: fromBuffer(order.maker),
           createdAt: new Date(order.created_at).toISOString(),
           validFrom: order.valid_from,
@@ -152,7 +154,7 @@ export class NewTopBidWebsocketEvent {
             JSON.stringify({
               event: "top-bid.changed",
               tags: {
-                collectionId: order.collection_id,
+                contract: order.contract,
               },
               data: payload,
             })

--- a/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
@@ -154,7 +154,7 @@ export class NewTopBidWebsocketEvent {
             JSON.stringify({
               event: "top-bid.changed",
               tags: {
-                contract: order.contract,
+                contract: fromBuffer(order.contract),
               },
               data: payload,
             })

--- a/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
@@ -148,9 +148,16 @@ export class NewTopBidWebsocketEvent {
       await Promise.all(
         payloads.map((payload) =>
           redisWebsocketPublisher.publish(
-            "top-bids",
+            "events",
             JSON.stringify({
               event: "top-bid.changed",
+              tags: {
+                collectionId: order.collection_id,
+                collectionSlug: order.collection_slug,
+                tokenSetId: order.token_set_id,
+                tokenId: order.token_id,
+                maker: order.maker,
+              },
               data: payload,
             })
           )

--- a/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
+++ b/packages/indexer/src/jobs/websocket-events/events/new-top-bid-websocket-event.ts
@@ -155,7 +155,7 @@ export class NewTopBidWebsocketEvent {
                 collectionId: order.collection_id,
                 collectionSlug: order.collection_slug,
                 tokenSetId: order.token_set_id,
-                tokenId: order.token_id,
+                tokenId: order.token_set_id.split(":")[2],
                 maker: order.maker,
               },
               data: payload,


### PR DESCRIPTION
- feat: add tags to websocket events
- feat: tweak token set id splitting
- fix: make tags for websocket event more simple
- feat: add contract to top bid websocket event
- fix: contract from buffer in ws tags
