### PR TITLE
Add alienswap contract and order

### DIFF
--- a/packages/contracts/contracts/router/modules/exchanges/AlienswapModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/AlienswapModule.sol
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import {BaseExchangeModule} from "./BaseExchangeModule.sol";
+import {BaseModule} from "../BaseModule.sol";
+import {ISeaport} from "../../../interfaces/ISeaport.sol";
+
+// Notes on the Seaport module:
+// - supports filling listings (both ERC721/ERC1155)
+// - supports filling offers (both ERC721/ERC1155)
+
+contract AlienswapModule is BaseExchangeModule {
+  // --- Structs ---
+
+  struct SeaportETHListingWithPrice {
+    ISeaport.AdvancedOrder order;
+    uint256 price;
+  }
+
+  // --- Fields ---
+
+  ISeaport public immutable EXCHANGE;
+
+  // --- Constructor ---
+
+  constructor(
+    address owner,
+    address router,
+    address exchange
+  ) BaseModule(owner) BaseExchangeModule(router) {
+    EXCHANGE = ISeaport(exchange);
+  }
+
+  // --- Fallback ---
+
+  receive() external payable {}
+
+  // --- Single ETH listing ---
+
+  function acceptETHListing(
+    ISeaport.AdvancedOrder calldata order,
+    ETHListingParams calldata params,
+    Fee[] calldata fees
+  )
+    external
+    payable
+    nonReentrant
+    refundETHLeftover(params.refundTo)
+    chargeETHFees(fees, params.amount)
+  {
+    // Execute the fill
+    params.revertIfIncomplete
+      ? _fillSingleOrderWithRevertIfIncomplete(
+        order,
+        new ISeaport.CriteriaResolver[](0),
+        params.fillTo,
+        params.amount
+      )
+      : _fillSingleOrder(order, new ISeaport.CriteriaResolver[](0), params.fillTo, params.amount);
+  }
+
+  // --- Single ERC20 listing ---
+
+  function acceptERC20Listing(
+    ISeaport.AdvancedOrder calldata order,
+    ERC20ListingParams calldata params,
+    Fee[] calldata fees
+  )
+    external
+    nonReentrant
+    refundERC20Leftover(params.refundTo, params.token)
+    chargeERC20Fees(fees, params.token, params.amount)
+  {
+    // Approve the exchange if needed
+    _approveERC20IfNeeded(params.token, address(EXCHANGE), params.amount);
+
+    // Execute the fill
+    params.revertIfIncomplete
+      ? _fillSingleOrderWithRevertIfIncomplete(
+        order,
+        new ISeaport.CriteriaResolver[](0),
+        params.fillTo,
+        0
+      )
+      : _fillSingleOrder(order, new ISeaport.CriteriaResolver[](0), params.fillTo, 0);
+  }
+
+  // --- Multiple ETH listings ---
+
+  function acceptETHListings(
+    SeaportETHListingWithPrice[] calldata orders,
+    ETHListingParams calldata params,
+    Fee[] calldata fees
+  )
+    external
+    payable
+    nonReentrant
+    refundETHLeftover(params.refundTo)
+    chargeETHFees(fees, params.amount)
+  {
+    uint256 length = orders.length;
+    ISeaport.CriteriaResolver[] memory criteriaResolvers = new ISeaport.CriteriaResolver[](0);
+
+    // Execute the fills
+    if (params.revertIfIncomplete) {
+      for (uint256 i; i < length; ) {
+        _fillSingleOrderWithRevertIfIncomplete(
+          orders[i].order,
+          criteriaResolvers,
+          params.fillTo,
+          orders[i].price
+        );
+
+        unchecked {
+          ++i;
+        }
+      }
+    } else {
+      for (uint256 i; i < length; ) {
+        _fillSingleOrder(orders[i].order, criteriaResolvers, params.fillTo, orders[i].price);
+
+        unchecked {
+          ++i;
+        }
+      }
+    }
+  }
+
+  // --- Multiple ERC20 listings ---
+
+  function acceptERC20Listings(
+    ISeaport.AdvancedOrder[] calldata orders,
+    ERC20ListingParams calldata params,
+    Fee[] calldata fees
+  )
+    external
+    nonReentrant
+    refundERC20Leftover(params.refundTo, params.token)
+    chargeERC20Fees(fees, params.token, params.amount)
+  {
+    // Approve the exchange if needed
+    _approveERC20IfNeeded(params.token, address(EXCHANGE), params.amount);
+
+    uint256 length = orders.length;
+    ISeaport.CriteriaResolver[] memory criteriaResolvers = new ISeaport.CriteriaResolver[](0);
+
+    // Execute the fills
+    if (params.revertIfIncomplete) {
+      for (uint256 i; i < length; ) {
+        _fillSingleOrderWithRevertIfIncomplete(orders[i], criteriaResolvers, params.fillTo, 0);
+
+        unchecked {
+          ++i;
+        }
+      }
+    } else {
+      for (uint256 i; i < length; ) {
+        _fillSingleOrder(orders[i], criteriaResolvers, params.fillTo, 0);
+
+        unchecked {
+          ++i;
+        }
+      }
+    }
+  }
+
+  // --- Single ERC721 offer ---
+
+  function acceptERC721Offer(
+    ISeaport.AdvancedOrder calldata order,
+    // Use `memory` instead of `calldata` to avoid `Stack too deep` errors
+    ISeaport.CriteriaResolver[] memory criteriaResolvers,
+    OfferParams calldata params,
+    Fee[] calldata fees
+  ) external nonReentrant {
+    // Extract the ERC721 token from the consideration items
+    ISeaport.ConsiderationItem calldata nftItem = order.parameters.consideration[0];
+    if (
+      nftItem.itemType != ISeaport.ItemType.ERC721 &&
+      nftItem.itemType != ISeaport.ItemType.ERC721_WITH_CRITERIA
+    ) {
+      revert WrongParams();
+    }
+    IERC721 nftToken = IERC721(nftItem.token);
+
+    // Extract the payment token from the offer items
+    ISeaport.OfferItem calldata paymentItem = order.parameters.offer[0];
+    IERC20 paymentToken = IERC20(paymentItem.token);
+
+    // Approve the exchange if needed
+    _approveERC721IfNeeded(nftToken, address(EXCHANGE));
+    _approveERC20IfNeeded(paymentToken, address(EXCHANGE), type(uint256).max);
+
+    // Execute the fill
+    params.revertIfIncomplete
+      ? _fillSingleOrderWithRevertIfIncomplete(order, criteriaResolvers, address(this), 0)
+      : _fillSingleOrder(order, criteriaResolvers, address(this), 0);
+
+    uint256 identifier = nftItem.itemType == ISeaport.ItemType.ERC721
+      ? nftItem.identifierOrCriteria
+      : criteriaResolvers[0].identifier;
+
+    // Pay fees
+    if (nftToken.ownerOf(identifier) != address(this)) {
+      // Only pay fees if the fill was successful
+      uint256 feesLength = fees.length;
+      for (uint256 i; i < feesLength; ) {
+        Fee memory fee = fees[i];
+        _sendERC20(fee.recipient, fee.amount, paymentToken);
+
+        unchecked {
+          ++i;
+        }
+      }
+    }
+
+    // Refund any ERC721 leftover
+    _sendAllERC721(params.refundTo, nftToken, identifier);
+
+    // Forward any left payment to the specified receiver
+    _sendAllERC20(params.fillTo, paymentToken);
+  }
+
+  // --- Single ERC1155 offer ---
+
+  function acceptERC1155Offer(
+    ISeaport.AdvancedOrder calldata order,
+    // Use `memory` instead of `calldata` to avoid `Stack too deep` errors
+    ISeaport.CriteriaResolver[] memory criteriaResolvers,
+    OfferParams calldata params,
+    Fee[] calldata fees
+  ) external nonReentrant {
+    // Extract the ERC1155 token from the consideration items
+    ISeaport.ConsiderationItem calldata nftItem = order.parameters.consideration[0];
+    if (
+      nftItem.itemType != ISeaport.ItemType.ERC1155 &&
+      nftItem.itemType != ISeaport.ItemType.ERC1155_WITH_CRITERIA
+    ) {
+      revert WrongParams();
+    }
+    IERC1155 nftToken = IERC1155(nftItem.token);
+
+    // Extract the payment token from the offer items
+    ISeaport.OfferItem calldata paymentItem = order.parameters.offer[0];
+    IERC20 paymentToken = IERC20(paymentItem.token);
+
+    // Approve the exchange if needed
+    _approveERC1155IfNeeded(nftToken, address(EXCHANGE));
+    _approveERC20IfNeeded(paymentToken, address(EXCHANGE), type(uint256).max);
+
+    uint256 identifier = nftItem.itemType == ISeaport.ItemType.ERC1155
+      ? nftItem.identifierOrCriteria
+      : criteriaResolvers[0].identifier;
+
+    uint256 balanceBefore = nftToken.balanceOf(address(this), identifier);
+
+    // Execute the fill
+    params.revertIfIncomplete
+      ? _fillSingleOrderWithRevertIfIncomplete(order, criteriaResolvers, address(this), 0)
+      : _fillSingleOrder(order, criteriaResolvers, address(this), 0);
+
+    uint256 balanceAfter = nftToken.balanceOf(address(this), identifier);
+
+    // Pay fees
+    uint256 amountFilled = balanceBefore - balanceAfter;
+    if (amountFilled > 0) {
+      uint256 feesLength = fees.length;
+      for (uint256 i; i < feesLength; ) {
+        Fee memory fee = fees[i];
+        _sendERC20(
+          fee.recipient,
+          // Only pay fees for the amount that was actually filled
+          (fee.amount * amountFilled) / order.numerator,
+          paymentToken
+        );
+
+        unchecked {
+          ++i;
+        }
+      }
+    }
+
+    // Refund any ERC1155 leftover
+    _sendAllERC1155(params.refundTo, nftToken, identifier);
+
+    // Forward any left payment to the specified receiver
+    _sendAllERC20(params.fillTo, paymentToken);
+  }
+
+  // --- Generic handler (used for Seaport-based approvals) ---
+
+  function matchOrders(
+    ISeaport.Order[] calldata orders,
+    ISeaport.Fulfillment[] calldata fulfillments
+  ) external nonReentrant {
+    // We don't perform any kind of input or return value validation,
+    // so this function should be used with precaution - the official
+    // way to use it is only for Seaport-based approvals
+    EXCHANGE.matchOrders(orders, fulfillments);
+  }
+
+  // --- ERC721 / ERC1155 hooks ---
+
+  // Single token offer acceptance can be done approval-less by using the
+  // standard `safeTransferFrom` method together with specifying data for
+  // further contract calls. An example:
+  // `safeTransferFrom(
+  //      0xWALLET,
+  //      0xMODULE,
+  //      TOKEN_ID,
+  //      0xABI_ENCODED_ROUTER_EXECUTION_CALLDATA_FOR_OFFER_ACCEPTANCE
+  // )`
+
+  function onERC721Received(
+    address, // operator,
+    address, // from
+    uint256, // tokenId,
+    bytes calldata data
+  ) external returns (bytes4) {
+    if (data.length > 0) {
+      _makeCall(router, data, 0);
+    }
+
+    return this.onERC721Received.selector;
+  }
+
+  function onERC1155Received(
+    address, // operator
+    address, // from
+    uint256, // tokenId
+    uint256, // amount
+    bytes calldata data
+  ) external returns (bytes4) {
+    if (data.length > 0) {
+      _makeCall(router, data, 0);
+    }
+
+    return this.onERC1155Received.selector;
+  }
+
+  // --- Internal ---
+
+  // NOTE: In lots of cases, Seaport will not revert if fills were not
+  // fully executed. An example of that is partial filling, which will
+  // successfully fill any amount that is still available (including a
+  // zero amount). One way to ensure that we revert in case of partial
+  // executions is to check the order's filled amount before and after
+  // we trigger the fill (we can use Seaport's `getOrderStatus` method
+  // to check). Since this can be expensive in terms of gas, we have a
+  // separate method variant to be called when reverts are enabled.
+
+  function _fillSingleOrder(
+    ISeaport.AdvancedOrder calldata order,
+    // Use `memory` instead of `calldata` to avoid `Stack too deep` errors
+    ISeaport.CriteriaResolver[] memory criteriaResolvers,
+    address receiver,
+    uint256 value
+  ) internal {
+    // Execute the fill
+    try
+      EXCHANGE.fulfillAdvancedOrder{value: value}(order, criteriaResolvers, bytes32(0), receiver)
+    {} catch {}
+  }
+
+  function _fillSingleOrderWithRevertIfIncomplete(
+    ISeaport.AdvancedOrder calldata order,
+    // Use `memory` instead of `calldata` to avoid `Stack too deep` errors
+    ISeaport.CriteriaResolver[] memory criteriaResolvers,
+    address receiver,
+    uint256 value
+  ) internal {
+    // Cache the order's hash
+    bytes32 orderHash = _getOrderHash(order.parameters);
+
+    // Before filling, get the order's filled amount
+    uint256 beforeFilledAmount = _getFilledAmount(orderHash);
+
+    // Execute the fill
+    bool success;
+    try
+      EXCHANGE.fulfillAdvancedOrder{value: value}(order, criteriaResolvers, bytes32(0), receiver)
+    returns (bool fulfilled) {
+      success = fulfilled;
+    } catch {
+      revert UnsuccessfulFill();
+    }
+
+    if (!success) {
+      revert UnsuccessfulFill();
+    } else {
+      // After successfully filling, get the order's filled amount
+      uint256 afterFilledAmount = _getFilledAmount(orderHash);
+
+      // Make sure the amount filled as part of this call is correct
+      if (afterFilledAmount - beforeFilledAmount != order.numerator) {
+        revert UnsuccessfulFill();
+      }
+    }
+  }
+
+  function _getOrderHash(
+    // Must use `memory` instead of `calldata` for the below cast
+    ISeaport.OrderParameters memory orderParameters
+  ) internal view returns (bytes32 orderHash) {
+    // `OrderParameters` and `OrderComponents` share the exact same
+    // fields, apart from the last one, so here we simply treat the
+    // `orderParameters` argument as `OrderComponents` and then set
+    // the last field to the correct data
+    ISeaport.OrderComponents memory orderComponents;
+    assembly {
+      orderComponents := orderParameters
+    }
+    orderComponents.counter = EXCHANGE.getCounter(orderParameters.offerer);
+
+    orderHash = EXCHANGE.getOrderHash(orderComponents);
+  }
+
+  function _getFilledAmount(bytes32 orderHash) internal view returns (uint256 totalFilled) {
+    (, , totalFilled, ) = EXCHANGE.getOrderStatus(orderHash);
+  }
+}

--- a/packages/contracts/scripts/create3/deploy.ts
+++ b/packages/contracts/scripts/create3/deploy.ts
@@ -126,6 +126,12 @@ export const triggerByModule = {
       Sdk.RouterV6.Addresses.Router[chainId],
       Sdk.SeaportV14.Addresses.Exchange[chainId],
     ]),
+  AlienswapModule: async (chainId: number) =>
+    dv("AlienswapModule", "v1", [
+      DEPLOYER,
+      Sdk.RouterV6.Addresses.Router[chainId],
+      Sdk.Alienswap.Addresses.Exchange[chainId],
+    ]),
   SudoswapModule: async (chainId: number) =>
     dv("SudoswapModule", "v1", [
       DEPLOYER,

--- a/packages/indexer/src/api/endpoints/collections/get-collection-supported-marketplaces/v1.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-collection-supported-marketplaces/v1.ts
@@ -150,9 +150,6 @@ export const getCollectionSupportedMarketplacesV1Options: RouteOptions = {
         );
       }
 
-      // Refresh opensea fees
-      await marketplaceFees.refreshCollectionOpenseaFeesAsync(params.collection);
-
       const openseaRoyalties: { bps: number; recipient: string }[] =
         collectionResult.new_royalties?.opensea;
 

--- a/packages/indexer/src/api/endpoints/execute/get-execute-buy/v7.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-buy/v7.ts
@@ -62,7 +62,8 @@ export const getExecuteBuyV7Options: RouteOptions = {
                   "infinity",
                   "sudoswap",
                   "flow",
-                  "nftx"
+                  "nftx",
+                  "alienswap"
                 )
                 .required(),
               data: Joi.object().required(),

--- a/packages/indexer/src/api/endpoints/execute/get-execute-cancel/v2.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-cancel/v2.ts
@@ -157,6 +157,16 @@ export const getExecuteCancelV2Options: RouteOptions = {
           break;
         }
 
+        case "alienswap": {
+          const order = new Sdk.Alienswap.Order(config.chainId, orderResult.raw_data);
+          const exchange = new Sdk.Alienswap.Exchange(config.chainId);
+
+          cancelTx = exchange.cancelOrderTx(maker, order);
+          orderSide = order.getInfo()!.side;
+
+          break;
+        }
+
         case "looks-rare": {
           const order = new Sdk.LooksRare.Order(config.chainId, orderResult.raw_data);
           const exchange = new Sdk.LooksRare.Exchange(config.chainId);

--- a/packages/indexer/src/api/endpoints/execute/get-execute-list/v5.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-list/v5.ts
@@ -29,6 +29,7 @@ import * as seaportCheck from "@/orderbook/orders/seaport-base/check";
 
 // Seaport v1.4
 import * as seaportV14SellToken from "@/orderbook/orders/seaport-v1.4/build/sell/token";
+import * as alienswapSellToken from "@/orderbook/orders/alienswap/build/sell/token";
 
 // X2Y2
 import * as x2y2SellToken from "@/orderbook/orders/x2y2/build/sell/token";
@@ -104,7 +105,8 @@ export const getExecuteListV5Options: RouteOptions = {
               "x2y2",
               "universe",
               "infinity",
-              "flow"
+              "flow",
+              "alienswap"
             )
             .default("seaport-v1.4")
             .description("Exchange protocol used to create order. Example: `seaport-v1.4`"),
@@ -257,19 +259,19 @@ export const getExecuteListV5Options: RouteOptions = {
         },
       ];
 
-      // Keep track of orders which can be signed in bulk
-      const bulkOrders = {
-        "seaport-v1.4": [] as {
-          order: {
-            kind: "seaport-v1.4";
-            data: Sdk.SeaportBase.Types.OrderComponents;
-          };
+      const bulkOrders = new Map<
+        Sdk.SeaportBase.SeaportOrderKind,
+        {
+          order: Sdk.SeaportBase.IOrder;
           orderbook: string;
           orderbookApiKey?: string;
           source?: string;
           orderIndex: number;
-        }[],
-      };
+        }[]
+      >([
+        [Sdk.SeaportBase.SeaportOrderKind.SEAPORT_V14, []],
+        [Sdk.SeaportBase.SeaportOrderKind.ALIENSWAP, []],
+      ]);
 
       // Handle Blur authentication
       let blurAuth: string | undefined;
@@ -800,13 +802,79 @@ export const getExecuteListV5Options: RouteOptions = {
                   orderIndexes: [i],
                 });
 
-                bulkOrders["seaport-v1.4"].push({
-                  order: {
-                    kind: params.orderKind,
-                    data: {
-                      ...order.params,
-                    },
-                  },
+                bulkOrders.get(order.getKind())!.push({
+                  order: order,
+                  orderbook: params.orderbook,
+                  orderbookApiKey: params.orderbookApiKey,
+                  source,
+                  orderIndex: i,
+                });
+
+                break;
+              }
+
+              case "alienswap": {
+                if (!["reservoir"].includes(params.orderbook)) {
+                  return errors.push({ message: "Unsupported orderbook", orderIndex: i });
+                }
+
+                const options = params.options?.[params.orderKind] as
+                  | {
+                      useOffChainCancellation?: boolean;
+                      replaceOrderId?: string;
+                    }
+                  | undefined;
+
+                const order = await alienswapSellToken.build({
+                  ...params,
+                  ...options,
+                  orderbook: params.orderbook as "reservoir" | "opensea",
+                  maker,
+                  contract,
+                  tokenId,
+                  source,
+                });
+
+                // Will be set if an approval is needed before listing
+                let approvalTx: TxData | undefined;
+
+                // Check the order's fillability
+                const exchange = new Sdk.Alienswap.Exchange(config.chainId);
+                try {
+                  await seaportCheck.offChainCheck(order, exchange, {
+                    onChainApprovalRecheck: true,
+                  });
+                } catch (error: any) {
+                  switch (error.message) {
+                    case "no-balance-no-approval":
+                    case "no-balance": {
+                      return errors.push({ message: "Maker does not own token", orderIndex: i });
+                    }
+
+                    case "no-approval": {
+                      // Generate an approval transaction
+                      const info = order.getInfo()!;
+
+                      const kind = order.params.kind?.startsWith("erc721") ? "erc721" : "erc1155";
+                      approvalTx = (
+                        kind === "erc721"
+                          ? new Sdk.Common.Helpers.Erc721(baseProvider, info.contract)
+                          : new Sdk.Common.Helpers.Erc1155(baseProvider, info.contract)
+                      ).approveTransaction(maker, exchange.deriveConduit(order.params.conduitKey));
+
+                      break;
+                    }
+                  }
+                }
+
+                steps[1].items.push({
+                  status: approvalTx ? "incomplete" : "complete",
+                  data: approvalTx,
+                  orderIndexes: [i],
+                });
+
+                bulkOrders.get(order.getKind())!.push({
+                  order: order,
                   orderbook: params.orderbook,
                   orderbookApiKey: params.orderbookApiKey,
                   source,
@@ -1071,64 +1139,67 @@ export const getExecuteListV5Options: RouteOptions = {
 
       // Post any bulk orders together
       {
-        const exchange = new Sdk.SeaportV14.Exchange(config.chainId);
-
-        const orders = bulkOrders["seaport-v1.4"];
-        if (orders.length === 1) {
-          const order = new Sdk.SeaportV14.Order(config.chainId, orders[0].order.data);
-          steps[2].items.push({
-            status: "incomplete",
-            data: {
-              sign: order.getSignatureData(),
-              post: {
-                endpoint: "/order/v3",
-                method: "POST",
-                body: {
-                  order: {
-                    kind: "seaport-v1.4",
-                    data: {
-                      ...order.params,
+        for (const [orderKind, orders] of bulkOrders) {
+          if (orders.length === 1) {
+            steps[2].items.push({
+              status: "incomplete",
+              data: {
+                sign: orders[0].order.getSignatureData(),
+                post: {
+                  endpoint: "/order/v3",
+                  method: "POST",
+                  body: {
+                    order: {
+                      kind: orderKind,
+                      data: { ...orders[0].order.params },
                     },
+                    orderbook: orders[0].orderbook,
+                    orderbookApiKey: orders[0].orderbookApiKey,
+                    source,
                   },
-                  orderbook: orders[0].orderbook,
-                  orderbookApiKey: orders[0].orderbookApiKey,
-                  source,
                 },
               },
-            },
-            orderIndexes: [orders[0].orderIndex],
-          });
-        } else if (orders.length > 1) {
-          const { signatureData, proofs } = exchange.getBulkSignatureDataWithProofs(
-            orders.map((o) => new Sdk.SeaportV14.Order(config.chainId, o.order.data))
-          );
+              orderIndexes: [orders[0].orderIndex],
+            });
+          } else if (orders.length > 1) {
+            let exchange: Sdk.SeaportV14.Exchange | Sdk.Alienswap.Exchange;
+            if (orderKind === Sdk.SeaportBase.SeaportOrderKind.SEAPORT_V14) {
+              exchange = new Sdk.SeaportV14.Exchange(config.chainId);
+            } else {
+              exchange = new Sdk.Alienswap.Exchange(config.chainId);
+            }
 
-          steps[2].items.push({
-            status: "incomplete",
-            data: {
-              sign: signatureData,
-              post: {
-                endpoint: "/order/v4",
-                method: "POST",
-                body: {
-                  items: orders.map((o, i) => ({
-                    order: o.order,
-                    orderbook: o.orderbook,
-                    orderbookApiKey: o.orderbookApiKey,
-                    bulkData: {
-                      kind: "seaport-v1.4",
-                      data: {
-                        orderIndex: i,
-                        merkleProof: proofs[i],
+            const { signatureData, proofs } = exchange.getBulkSignatureDataWithProofs(
+              orders.map((o) => o.order)
+            );
+
+            steps[2].items.push({
+              status: "incomplete",
+              data: {
+                sign: signatureData,
+                post: {
+                  endpoint: "/order/v4",
+                  method: "POST",
+                  body: {
+                    items: orders.map((o, i) => ({
+                      order: o.order,
+                      orderbook: o.orderbook,
+                      orderbookApiKey: o.orderbookApiKey,
+                      bulkData: {
+                        kind: orderKind,
+                        data: {
+                          orderIndex: i,
+                          merkleProof: proofs[i],
+                        },
                       },
-                    },
-                  })),
-                  source,
+                    })),
+                    source,
+                  },
                 },
               },
-            },
-            orderIndexes: orders.map(({ orderIndex }) => orderIndex),
-          });
+              orderIndexes: orders.map(({ orderIndex }) => orderIndex),
+            });
+          }
         }
       }
 

--- a/packages/indexer/src/api/endpoints/orders/post-order/v3.ts
+++ b/packages/indexer/src/api/endpoints/orders/post-order/v3.ts
@@ -281,54 +281,6 @@ export const postOrderV3Options: RouteOptions = {
                   orderbookApiKey: config.forwardOpenseaApiKey,
                 });
               }
-            } else {
-              const collectionResult = await idb.oneOrNone(
-                `
-                  SELECT
-                    collections.new_royalties,
-                    orders.token_set_id
-                  FROM orders
-                  JOIN token_sets_tokens
-                    ON orders.token_set_id = token_sets_tokens.token_set_id
-                  JOIN tokens
-                    ON tokens.contract = token_sets_tokens.contract
-                    AND tokens.token_id = token_sets_tokens.token_id
-                  JOIN collections
-                    ON tokens.collection_id = collections.id
-                  WHERE orders.id = $/id/
-                  LIMIT 1
-                `,
-                { id: orderId }
-              );
-
-              if (
-                collectionResult?.token_set_id?.startsWith("token") &&
-                collectionResult?.new_royalties?.["opensea"]
-              ) {
-                const osRoyaltyRecipients = collectionResult.new_royalties["opensea"].map(
-                  (r: any) => r.recipient.toLowerCase()
-                );
-                const maker = order.data.offerer.toLowerCase();
-                const consideration = order.data.consideration;
-
-                let hasMarketplaceFee = false;
-                for (const c of consideration) {
-                  const recipient = c.recipient.toLowerCase();
-                  if (recipient !== maker && !osRoyaltyRecipients.includes(recipient)) {
-                    hasMarketplaceFee = true;
-                  }
-                }
-
-                if (!hasMarketplaceFee) {
-                  await postOrderExternal.addToQueue({
-                    orderId,
-                    orderData: order.data,
-                    orderSchema: schema,
-                    orderbook: "opensea",
-                    orderbookApiKey: config.openSeaApiKey,
-                  });
-                }
-              }
             }
           }
 

--- a/packages/indexer/src/api/endpoints/orders/post-order/v3.ts
+++ b/packages/indexer/src/api/endpoints/orders/post-order/v3.ts
@@ -48,7 +48,8 @@ export const postOrderV3Options: RouteOptions = {
             "universe",
             "forward",
             "infinity",
-            "flow"
+            "flow",
+            "alienswap"
           )
           .required(),
         data: Joi.object().required(),
@@ -200,6 +201,7 @@ export const postOrderV3Options: RouteOptions = {
           }
         }
 
+        case "alienswap":
         case "seaport":
         case "seaport-v1.4": {
           if (!["opensea", "reservoir"].includes(orderbook)) {
@@ -208,10 +210,18 @@ export const postOrderV3Options: RouteOptions = {
 
           let crossPostingOrder;
 
-          const orderId =
-            order.kind === "seaport"
-              ? new Sdk.SeaportV11.Order(config.chainId, order.data).hash()
-              : new Sdk.SeaportV14.Order(config.chainId, order.data).hash();
+          let orderId = "";
+          switch (order.kind) {
+            case "seaport":
+              orderId = new Sdk.SeaportV11.Order(config.chainId, order.data).hash();
+              break;
+            case "seaport-v1.4":
+              orderId = new Sdk.SeaportV14.Order(config.chainId, order.data).hash();
+              break;
+            case "alienswap":
+              orderId = new Sdk.SeaportV11.Order(config.chainId, order.data).hash();
+              break;
+          }
 
           if (orderbook === "opensea") {
             crossPostingOrder = await crossPostingOrdersModel.saveOrder({

--- a/packages/indexer/src/api/endpoints/orders/post-order/v4.ts
+++ b/packages/indexer/src/api/endpoints/orders/post-order/v4.ts
@@ -372,54 +372,6 @@ export const postOrderV4Options: RouteOptions = {
                       orderbookApiKey: config.forwardOpenseaApiKey,
                     });
                   }
-                } else {
-                  const collectionResult = await idb.oneOrNone(
-                    `
-                      SELECT
-                        collections.new_royalties,
-                        orders.token_set_id
-                      FROM orders
-                      JOIN token_sets_tokens
-                        ON orders.token_set_id = token_sets_tokens.token_set_id
-                      JOIN tokens
-                        ON tokens.contract = token_sets_tokens.contract
-                        AND tokens.token_id = token_sets_tokens.token_id
-                      JOIN collections
-                        ON tokens.collection_id = collections.id
-                      WHERE orders.id = $/id/
-                      LIMIT 1
-                    `,
-                    { id: orderId }
-                  );
-
-                  if (
-                    collectionResult?.token_set_id?.startsWith("token") &&
-                    collectionResult?.new_royalties?.["opensea"]
-                  ) {
-                    const osRoyaltyRecipients = collectionResult.new_royalties["opensea"].map(
-                      (r: any) => r.recipient.toLowerCase()
-                    );
-                    const maker = order.data.offerer.toLowerCase();
-                    const consideration = order.data.consideration;
-
-                    let hasMarketplaceFee = false;
-                    for (const c of consideration) {
-                      const recipient = c.recipient.toLowerCase();
-                      if (recipient !== maker && !osRoyaltyRecipients.includes(recipient)) {
-                        hasMarketplaceFee = true;
-                      }
-                    }
-
-                    if (!hasMarketplaceFee) {
-                      await postOrderExternal.addToQueue({
-                        orderId,
-                        orderData: order.data,
-                        orderSchema: schema,
-                        orderbook: "opensea",
-                        orderbookApiKey: config.openSeaApiKey,
-                      });
-                    }
-                  }
                 }
               }
 

--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -276,6 +276,10 @@ export const start = async (): Promise<void> => {
 
     // Set custom response in case of timeout
     if ("isBoom" in response && "output" in response) {
+      if (response["output"]["statusCode"] >= 500) {
+        ApiKeyManager.logUnexpectedErrorResponse(request, response);
+      }
+
       if (response["output"]["statusCode"] == 503) {
         const timeoutResponse = {
           statusCode: 504,
@@ -284,10 +288,6 @@ export const start = async (): Promise<void> => {
         };
 
         return reply.response(timeoutResponse).type("application/json").code(504);
-      }
-
-      if (response["output"]["statusCode"] >= 500) {
-        ApiKeyManager.logUnexpectedErrorResponse(request, response);
       }
     }
 

--- a/packages/indexer/src/config/network.ts
+++ b/packages/indexer/src/config/network.ts
@@ -418,7 +418,7 @@ export const getNetworkSettings = (): NetworkSettings => {
       return {
         ...defaultNetworkSettings,
         enableWebSocket: false,
-        realtimeSyncMaxBlockLag: 16,
+        realtimeSyncMaxBlockLag: 32,
         realtimeSyncFrequencySeconds: 5,
         lastBlockLatency: 5,
         subDomain: "api-arbitrum",

--- a/packages/indexer/src/jobs/arweave-relay/index.ts
+++ b/packages/indexer/src/jobs/arweave-relay/index.ts
@@ -13,7 +13,7 @@ const PENDING_DATA_KEY = "pending-arweave-data";
 
 export const addPendingOrdersSeaport = async (
   data: {
-    order: Sdk.SeaportV11.Order;
+    order: Sdk.SeaportBase.IOrder;
     schemaHash?: string;
     source?: string;
   }[]
@@ -23,30 +23,7 @@ export const addPendingOrdersSeaport = async (
       PENDING_DATA_KEY,
       ...data.map(({ order, schemaHash }) =>
         JSON.stringify({
-          kind: "seaport",
-          data: {
-            ...order.params,
-            schemaHash,
-          },
-        })
-      )
-    );
-  }
-};
-
-export const addPendingOrdersSeaportV14 = async (
-  data: {
-    order: Sdk.SeaportV14.Order;
-    schemaHash?: string;
-    source?: string;
-  }[]
-) => {
-  if (config.arweaveRelayerKey && data.length) {
-    await redis.rpush(
-      PENDING_DATA_KEY,
-      ...data.map(({ order, schemaHash }) =>
-        JSON.stringify({
-          kind: "seaport-v1.4",
+          kind: order.getKind(),
           data: {
             ...order.params,
             schemaHash,

--- a/packages/indexer/src/jobs/events-sync/process/realtime.ts
+++ b/packages/indexer/src/jobs/events-sync/process/realtime.ts
@@ -55,7 +55,7 @@ if (
         throw error;
       }
     },
-    { connection: redis.duplicate(), concurrency: config.chainId === 137 ? 10 : 20 }
+    { connection: redis.duplicate(), concurrency: config.chainId === 137 ? 5 : 20 }
   );
 
   worker.on("error", (error) => {

--- a/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
@@ -83,7 +83,7 @@ if (config.doBackgroundWork) {
 
       if (isRateLimited) {
         // If limit reached, reschedule job based on the limit expiration.
-        logger.info(
+        logger.debug(
           QUEUE_NAME,
           `Post Order Rate Limited. orderbook=${orderbook}, crossPostingOrderId=${crossPostingOrderId}, orderId=${orderId}, orderData=${JSON.stringify(
             orderData
@@ -272,15 +272,6 @@ const postOrder = async (
       const order = new Sdk.SeaportV14.Order(
         config.chainId,
         orderData as Sdk.SeaportBase.Types.OrderComponents
-      );
-
-      logger.info(
-        QUEUE_NAME,
-        `Post Order Seaport. orderbook=${orderbook}, orderId=${orderId}, orderSchema=${JSON.stringify(
-          orderSchema
-        )}, orderData=${JSON.stringify(orderData)}, side=${order.getInfo()?.side}, kind=${
-          order.params.kind
-        }`
       );
 
       if (

--- a/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
@@ -128,7 +128,7 @@ if (config.doBackgroundWork) {
 
             logger.info(
               QUEUE_NAME,
-              `Post Order Throttled. orderbook=${orderbook}, crossPostingOrderId=${crossPostingOrderId}, orderId=${orderId}, orderData=${JSON.stringify(
+              `Post Order Throttled. orderbook=${orderbook}, orderbookApiKey=${orderbookApiKey}, crossPostingOrderId=${crossPostingOrderId}, orderId=${orderId}, orderData=${JSON.stringify(
                 orderData
               )}, delay=${delay}, retry=${retry}`
             );

--- a/packages/indexer/src/migrations/1680587022129_add-alienswap-order-kind.sql
+++ b/packages/indexer/src/migrations/1680587022129_add-alienswap-order-kind.sql
@@ -1,0 +1,5 @@
+-- Up Migration
+
+ALTER TYPE "order_kind_t" ADD VALUE 'alienswap';
+
+-- Down Migration

--- a/packages/indexer/src/orderbook/orders/alienswap/build/buy/attribute.ts
+++ b/packages/indexer/src/orderbook/orders/alienswap/build/buy/attribute.ts
@@ -1,0 +1,146 @@
+import * as Sdk from "@reservoir0x/sdk";
+import { BigNumberish } from "@ethersproject/bignumber";
+
+import { redb } from "@/common/db";
+import { fromBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { getBuildInfo } from "../utils";
+import { BaseOrderBuildOptions } from "../../../seaport-base/build/utils";
+import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
+
+interface BuildOrderOptions extends BaseOrderBuildOptions {
+  // TODO: refactor
+  // The following combinations are possible:
+  // - collection + attributes
+  // - tokenSetId
+  tokenSetId?: string;
+  collection?: string;
+  attributes?: { key: string; value: string }[];
+}
+
+export const build = async (options: BuildOrderOptions) => {
+  const builder = new Sdk.SeaportBase.Builders.TokenList(config.chainId);
+
+  if (options.collection && options.attributes) {
+    let merkleRoot;
+    let tokenIds: BigNumberish[] = [];
+    if (options.attributes.length !== 1) {
+      throw new Error("Attribute bids must be on a single attribute");
+    }
+
+    const attributeResult = await redb.oneOrNone(
+      `
+        SELECT
+          collections.contract,
+          collections.slug AS "collectionSlug",
+          attributes.token_count
+        FROM attributes
+        JOIN attribute_keys
+          ON attributes.attribute_key_id = attribute_keys.id
+        JOIN collections
+          ON attribute_keys.collection_id = collections.id
+        WHERE attribute_keys.collection_id = $/collection/
+          AND attribute_keys.key = $/key/
+          AND attributes.value = $/value/
+      `,
+      {
+        collection: options.collection,
+        key: options.attributes[0].key,
+        value: options.attributes[0].value,
+      }
+    );
+    if (!attributeResult) {
+      throw new Error("Could not retrieve attribute info");
+    }
+
+    if (Number(attributeResult.token_count) > config.maxTokenSetSize) {
+      throw new Error("Attribute has too many items");
+    }
+
+    const buildInfo = await getBuildInfo(
+      {
+        ...options,
+        contract: fromBuffer(attributeResult.contract),
+      },
+      options.collection,
+      "buy"
+    );
+
+    if (options.orderbook === "opensea") {
+      const buildCollectionOfferParams = await OpenSeaApi.buildTraitOffer(
+        options.maker,
+        options.quantity || 1,
+        attributeResult.collectionSlug,
+        options.attributes[0].key,
+        options.attributes[0].value
+      );
+
+      // When cross-posting to OpenSea, if the result from their API is not
+      // a contract-wide order, then switch to using a token-list builder
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      merkleRoot =
+        buildCollectionOfferParams.partialParameters.consideration[0].identifierOrCriteria;
+    } else {
+      const excludeFlaggedTokens = options.excludeFlaggedTokens
+        ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
+        : "";
+
+      // Fetch all tokens matching the attributes
+      const tokens = await redb.manyOrNone(
+        `
+        SELECT
+          token_attributes.token_id
+        FROM token_attributes
+        JOIN attributes
+          ON token_attributes.attribute_id = attributes.id
+        JOIN attribute_keys
+          ON attributes.attribute_key_id = attribute_keys.id
+        JOIN tokens
+          ON token_attributes.contract = tokens.contract
+          AND token_attributes.token_id = tokens.token_id
+        WHERE attribute_keys.collection_id = $/collection/
+          AND attribute_keys.key = $/key/
+          AND attributes.value = $/value/
+          ${excludeFlaggedTokens}
+        ORDER BY token_attributes.token_id
+      `,
+        {
+          collection: options.collection,
+          key: options.attributes[0].key,
+          value: options.attributes[0].value,
+        }
+      );
+
+      tokenIds = tokens.map(({ token_id }) => token_id);
+    }
+
+    return builder?.build({ ...buildInfo.params, tokenIds, merkleRoot }, Sdk.Alienswap.Order);
+  } else {
+    // Fetch all tokens matching the token set
+    const tokens = await redb.manyOrNone(
+      `
+        SELECT
+          token_sets_tokens.contract,
+          token_sets_tokens.token_id
+        FROM token_sets_tokens
+        WHERE token_sets_tokens.token_set_id = $/tokenSetId/
+      `,
+      {
+        tokenSetId: options.tokenSetId!,
+      }
+    );
+
+    const buildInfo = await getBuildInfo(
+      {
+        ...options,
+        contract: fromBuffer(tokens[0].contract),
+      },
+      fromBuffer(tokens[0].contract),
+      "buy"
+    );
+
+    const tokenIds = tokens.map(({ token_id }) => token_id);
+
+    return builder?.build({ ...buildInfo.params, tokenIds }, Sdk.Alienswap.Order);
+  }
+};

--- a/packages/indexer/src/orderbook/orders/alienswap/build/buy/collection.ts
+++ b/packages/indexer/src/orderbook/orders/alienswap/build/buy/collection.ts
@@ -1,0 +1,141 @@
+import * as Sdk from "@reservoir0x/sdk";
+import { generateMerkleTree } from "@reservoir0x/sdk/dist/common/helpers";
+
+import { idb } from "@/common/db";
+import { redis } from "@/common/redis";
+import { fromBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { getBuildInfo } from "../utils";
+import { BaseOrderBuildOptions } from "../../../seaport-base/build/utils";
+import { generateSchemaHash } from "@/orderbook/orders/utils";
+import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
+import { Tokens } from "@/models/tokens";
+
+interface BuildOrderOptions extends BaseOrderBuildOptions {
+  collection: string;
+}
+
+export const build = async (options: BuildOrderOptions) => {
+  // Fetch some details about the collection
+  const collectionResult = await idb.oneOrNone(
+    `
+      SELECT
+        collections.token_set_id,
+        collections.token_count,
+        collections.contract,
+        collections.slug,
+        collections.non_flagged_token_set_id
+      FROM collections
+      WHERE collections.id = $/collection/
+    `,
+    { collection: options.collection }
+  );
+  if (!collectionResult) {
+    throw new Error("Could not retrieve collection");
+  }
+  if (Number(collectionResult.token_count) > config.maxTokenSetSize) {
+    throw new Error("Collection has too many tokens");
+  }
+
+  const buildInfo = await getBuildInfo(
+    {
+      ...options,
+      contract: fromBuffer(collectionResult.contract),
+    },
+    options.collection,
+    "buy"
+  );
+
+  const collectionIsContractWide = collectionResult.token_set_id?.startsWith("contract:");
+  if (collectionIsContractWide && !options.excludeFlaggedTokens) {
+    // By default, use a contract-wide builder
+    let builder: Sdk.SeaportBase.BaseBuilder = new Sdk.SeaportBase.Builders.ContractWide(
+      config.chainId
+    );
+
+    if (options.orderbook === "opensea") {
+      const buildCollectionOfferParams = await OpenSeaApi.buildCollectionOffer(
+        options.maker,
+        options.quantity || 1,
+        collectionResult.slug
+      );
+
+      // When cross-posting to OpenSea, if the result from their API is not
+      // a contract-wide order, then switch to using a token-list builder
+      if (
+        buildCollectionOfferParams.partialParameters.consideration[0].identifierOrCriteria != "0"
+      ) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (buildInfo.params as any).merkleRoot =
+          buildCollectionOfferParams.partialParameters.consideration[0].identifierOrCriteria;
+
+        builder = new Sdk.SeaportBase.Builders.TokenList(config.chainId);
+      }
+    }
+
+    return builder.build(buildInfo.params, Sdk.Alienswap.Order);
+  } else {
+    // Use a token-list builder
+    const builder: Sdk.SeaportBase.BaseBuilder = new Sdk.SeaportBase.Builders.TokenList(
+      config.chainId
+    );
+
+    if (options.orderbook === "opensea") {
+      // We need to fetch from OpenSea the most up-to-date merkle root
+      // (currently only supported on production APIs)
+      const buildCollectionOfferParams = await OpenSeaApi.buildCollectionOffer(
+        options.maker,
+        options.quantity || 1,
+        collectionResult.slug
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (buildInfo.params as any).merkleRoot =
+        buildCollectionOfferParams.partialParameters.consideration[0].identifierOrCriteria;
+    } else {
+      // For up-to-date results we need to compute the corresponding token set id
+      // from the tokens table. However, that can be computationally-expensive so
+      // we go through two levels of caches before performing the computation.
+      let cachedMerkleRoot: string | null = null;
+
+      if (options.excludeFlaggedTokens && collectionResult.non_flagged_token_set_id) {
+        // Attempt 1: fetch the token set id for non-flagged tokens directly from the collection
+        cachedMerkleRoot = collectionResult.non_flagged_token_set_id.split(":")[2];
+      }
+
+      // Build the resulting token set's schema
+      const schema = {
+        kind: options.excludeFlaggedTokens ? "collection-non-flagged" : "collection",
+        data: {
+          collection: options.collection,
+        },
+      };
+      const schemaHash = generateSchemaHash(schema);
+
+      if (!cachedMerkleRoot) {
+        // Attempt 2: use a cached version of the token set
+        cachedMerkleRoot = await redis.get(schemaHash);
+      }
+
+      if (!cachedMerkleRoot) {
+        // Attempt 3 (final - will definitely work): compute the token set id (can be computationally-expensive)
+
+        // Fetch all relevant tokens from the collection
+        const tokenIds = await Tokens.getTokenIdsInCollection(
+          options.collection,
+          "",
+          options.excludeFlaggedTokens
+        );
+
+        // Also cache the computation for one hour
+        cachedMerkleRoot = generateMerkleTree(tokenIds).getHexRoot();
+        await redis.set(schemaHash, cachedMerkleRoot, "EX", 3600);
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (buildInfo.params as any).merkleRoot = cachedMerkleRoot;
+    }
+
+    return builder.build(buildInfo.params, Sdk.Alienswap.Order);
+  }
+};

--- a/packages/indexer/src/orderbook/orders/alienswap/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/alienswap/build/buy/token.ts
@@ -1,0 +1,12 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { getBuildInfo } from "../utils";
+import {
+  BuyTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/buy/token";
+
+export const build = async (options: BuildOrderOptions) => {
+  const builder = new BuyTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.Alienswap.Order);
+};

--- a/packages/indexer/src/orderbook/orders/alienswap/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/alienswap/build/sell/token.ts
@@ -1,0 +1,12 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { getBuildInfo } from "../utils";
+import {
+  SellTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/sell/token";
+
+export const build = async (options: BuildOrderOptions) => {
+  const builder = new SellTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.Alienswap.Order);
+};

--- a/packages/indexer/src/orderbook/orders/alienswap/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/alienswap/build/utils.ts
@@ -1,0 +1,111 @@
+import { AddressZero } from "@ethersproject/constants";
+import * as Sdk from "@reservoir0x/sdk";
+import { getRandomBytes } from "@reservoir0x/sdk/dist/utils";
+
+import { redb } from "@/common/db";
+import { baseProvider } from "@/common/provider";
+import { bn, now } from "@/common/utils";
+import { config } from "@/config/index";
+import {
+  BaseOrderBuildOptions,
+  OrderBuildInfo,
+  padSourceToSalt,
+} from "@/orderbook/orders/seaport-base/build/utils";
+
+export const getBuildInfo = async (
+  options: BaseOrderBuildOptions,
+  collection: string,
+  side: "sell" | "buy"
+): Promise<OrderBuildInfo> => {
+  const collectionResult = await redb.oneOrNone(
+    `
+      SELECT
+        contracts.kind,
+        collections.royalties,
+        collections.new_royalties,
+        collections.marketplace_fees,
+        collections.contract
+      FROM collections
+      JOIN contracts
+        ON collections.contract = contracts.address
+      WHERE collections.id = $/collection/
+      LIMIT 1
+    `,
+    { collection }
+  );
+  if (!collectionResult) {
+    throw new Error("Could not fetch collection");
+  }
+
+  const exchange = new Sdk.Alienswap.Exchange(config.chainId);
+
+  // Use alienswap's conduit key
+  const conduitKey = Sdk.Alienswap.Addresses.OpenseaConduitKey[config.chainId];
+
+  // No zone by default
+  const zone = AddressZero;
+
+  const source = options.source;
+
+  // Generate the salt
+  let salt = source
+    ? padSourceToSalt(source, options.salt ?? getRandomBytes(16).toString())
+    : undefined;
+  if (options.replaceOrderId) {
+    salt = options.replaceOrderId;
+  }
+
+  const buildParams: Sdk.SeaportBase.BaseBuildParams = {
+    offerer: options.maker,
+    side,
+    tokenKind: collectionResult.kind,
+    // TODO: Fix types
+    contract: options.contract!,
+    price: options.weiPrice,
+    amount: options.quantity,
+    paymentToken: options.currency
+      ? options.currency
+      : side === "buy"
+      ? Sdk.Common.Addresses.Weth[config.chainId]
+      : Sdk.Common.Addresses.Eth[config.chainId],
+    fees: [],
+    zone,
+    conduitKey,
+    salt,
+    startTime: options.listingTime || now() - 1 * 60,
+    endTime: options.expirationTime || now() + 6 * 30 * 24 * 3600,
+    counter: (await exchange.getCounter(baseProvider, options.maker)).toString(),
+    orderType: options.orderType,
+  };
+
+  // Keep track of the total amount of fees
+  let totalFees = bn(0);
+  if (options.fee && options.feeRecipient) {
+    for (let i = 0; i < options.fee.length; i++) {
+      if (Number(options.fee[i]) > 0) {
+        const fee = bn(options.fee[i]).mul(options.weiPrice).div(10000);
+        if (fee.gt(0)) {
+          buildParams.fees!.push({
+            recipient: options.feeRecipient[i],
+            amount: fee.toString(),
+          });
+          totalFees = totalFees.add(fee);
+        }
+      }
+    }
+  }
+
+  // If the order is a listing, subtract the fees from the price.
+  // Otherwise, keep them (since the taker will pay them from the
+  // amount received from the maker).
+  if (side === "sell") {
+    buildParams.price = bn(buildParams.price).sub(totalFees);
+  } else {
+    buildParams.price = bn(buildParams.price);
+  }
+
+  return {
+    params: buildParams,
+    kind: collectionResult.kind,
+  };
+};

--- a/packages/indexer/src/orderbook/orders/index.ts
+++ b/packages/indexer/src/orderbook/orders/index.ts
@@ -9,6 +9,7 @@ export * as foundation from "@/orderbook/orders/foundation";
 export * as looksRare from "@/orderbook/orders/looks-rare";
 export * as seaport from "@/orderbook/orders/seaport-v1.1";
 export * as seaportV14 from "@/orderbook/orders/seaport-v1.4";
+export * as alienswap from "@/orderbook/orders/alienswap";
 export * as sudoswap from "@/orderbook/orders/sudoswap";
 export * as x2y2 from "@/orderbook/orders/x2y2";
 export * as zeroExV4 from "@/orderbook/orders/zeroex-v4";
@@ -49,6 +50,7 @@ export type OrderKind =
   | "x2y2"
   | "seaport"
   | "seaport-v1.4"
+  | "alienswap"
   | "rarible"
   | "element-erc721"
   | "element-erc1155"
@@ -342,6 +344,15 @@ export const generateListingDetailsV6 = (
           } as any,
         };
       }
+    }
+
+    // doesn't support partial order
+    case "alienswap": {
+      return {
+        kind: "alienswap",
+        ...common,
+        order: new Sdk.Alienswap.Order(config.chainId, order.rawData),
+      };
     }
 
     case "zora-v3": {

--- a/packages/indexer/src/orderbook/orders/seaport-base/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-base/build/buy/token.ts
@@ -1,0 +1,65 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { redb } from "@/common/db";
+import { toBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { BaseOrderBuildOptions, OrderBuildInfo } from "../utils";
+
+export interface BuildOrderOptions extends BaseOrderBuildOptions {
+  contract: string;
+  tokenId: string;
+}
+
+export class BuyTokenBuilderBase {
+  private getBuildInfoFunc: (
+    options: BaseOrderBuildOptions,
+    collection: string,
+    side: "sell" | "buy"
+  ) => Promise<OrderBuildInfo>;
+
+  constructor(
+    getBuildInfoFunc: (
+      options: BaseOrderBuildOptions,
+      collection: string,
+      side: "sell" | "buy"
+    ) => Promise<OrderBuildInfo>
+  ) {
+    this.getBuildInfoFunc = getBuildInfoFunc;
+  }
+
+  public async build<T extends Sdk.SeaportBase.IOrder>(
+    options: BuildOrderOptions,
+    orderBuilder: { new (chainId: number, params: Sdk.SeaportBase.Types.OrderComponents): T }
+  ): Promise<T> {
+    const excludeFlaggedTokens = options.excludeFlaggedTokens
+      ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
+      : "";
+
+    const collectionResult = await redb.oneOrNone(
+      `
+            SELECT
+              tokens.collection_id
+            FROM tokens
+            WHERE tokens.contract = $/contract/
+            AND tokens.token_id = $/tokenId/
+            ${excludeFlaggedTokens}
+          `,
+      {
+        contract: toBuffer(options.contract),
+        tokenId: options.tokenId,
+      }
+    );
+    if (!collectionResult) {
+      throw new Error("Could not retrieve token's collection");
+    }
+
+    const buildInfo = await this.getBuildInfoFunc(options, collectionResult.collection_id, "buy");
+
+    const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
+
+    return builder.build(
+      { ...buildInfo.params, tokenId: options.tokenId, amount: options.quantity },
+      orderBuilder
+    );
+  }
+}

--- a/packages/indexer/src/orderbook/orders/seaport-base/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-base/build/sell/token.ts
@@ -1,0 +1,56 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { redb } from "@/common/db";
+import { toBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { BaseOrderBuildOptions, OrderBuildInfo } from "../utils";
+
+export interface BuildOrderOptions extends BaseOrderBuildOptions {
+  tokenId: string;
+}
+
+export class SellTokenBuilderBase {
+  private getBuildInfoFunc: (
+    options: BaseOrderBuildOptions,
+    collection: string,
+    side: "sell" | "buy"
+  ) => Promise<OrderBuildInfo>;
+
+  constructor(
+    getBuildInfoFunc: (
+      options: BaseOrderBuildOptions,
+      collection: string,
+      side: "sell" | "buy"
+    ) => Promise<OrderBuildInfo>
+  ) {
+    this.getBuildInfoFunc = getBuildInfoFunc;
+  }
+
+  public async build<T extends Sdk.SeaportBase.IOrder>(
+    options: BuildOrderOptions,
+    orderBuilder: { new (chainId: number, params: Sdk.SeaportBase.Types.OrderComponents): T }
+  ): Promise<T> {
+    const collectionResult = await redb.oneOrNone(
+      `
+              SELECT
+                tokens.collection_id
+              FROM tokens
+              WHERE tokens.contract = $/contract/
+                AND tokens.token_id = $/tokenId/
+            `,
+      {
+        contract: toBuffer(options.contract!),
+        tokenId: options.tokenId,
+      }
+    );
+    if (!collectionResult) {
+      throw new Error("Could not retrieve token's collection");
+    }
+
+    const buildInfo = await this.getBuildInfoFunc(options, collectionResult.collection_id, "sell");
+
+    const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
+
+    return builder.build({ ...buildInfo.params, tokenId: options.tokenId }, orderBuilder);
+  }
+}

--- a/packages/indexer/src/orderbook/orders/seaport-base/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-base/build/utils.ts
@@ -1,0 +1,37 @@
+import * as Sdk from "@reservoir0x/sdk";
+import { generateSourceBytes } from "@reservoir0x/sdk/dist/utils";
+
+import { bn } from "@/common/utils";
+
+export interface BaseOrderBuildOptions {
+  maker: string;
+  contract?: string;
+  weiPrice: string;
+  orderbook: "opensea" | "reservoir";
+  useOffChainCancellation?: boolean;
+  replaceOrderId?: string;
+  orderType?: Sdk.SeaportBase.Types.OrderType;
+  currency?: string;
+  quantity?: number;
+  nonce?: string;
+  fee?: number[];
+  feeRecipient?: string[];
+  listingTime?: number;
+  expirationTime?: number;
+  salt?: string;
+  automatedRoyalties?: boolean;
+  royaltyBps?: number;
+  excludeFlaggedTokens?: boolean;
+  source?: string;
+}
+
+export type OrderBuildInfo = {
+  params: Sdk.SeaportBase.BaseBuildParams;
+  kind: "erc721" | "erc1155";
+};
+
+export const padSourceToSalt = (source: string, salt: string) => {
+  const sourceHash = generateSourceBytes(source);
+  const saltHex = bn(salt)._hex.slice(6);
+  return bn(`0x${sourceHash}${saltHex}`).toString();
+};

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/attribute.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/attribute.ts
@@ -3,9 +3,10 @@ import * as Sdk from "@reservoir0x/sdk";
 import { redb } from "@/common/db";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.1/build/utils";
+import { BaseOrderBuildOptions } from "@/orderbook/orders/seaport-base/build/utils";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   // TODO: refactor
   // The following combinations are possible:
   // - collection + attributes
@@ -51,7 +52,7 @@ export const build = async (options: BuildOrderOptions) => {
       throw new Error("Attribute has too many items");
     }
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(attributeResult.contract),
@@ -108,7 +109,7 @@ export const build = async (options: BuildOrderOptions) => {
       }
     );
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(tokens[0].contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/collection.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/collection.ts
@@ -5,12 +5,13 @@ import { idb } from "@/common/db";
 import { redis } from "@/common/redis";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
+import { BaseOrderBuildOptions } from "@/orderbook/orders/seaport-base/build/utils";
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.1/build/utils";
 import { generateSchemaHash } from "@/orderbook/orders/utils";
 import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
 import { Tokens } from "@/models/tokens";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   collection: string;
 }
 
@@ -36,7 +37,7 @@ export const build = async (options: BuildOrderOptions) => {
     throw new Error("Collection has too many tokens");
   }
 
-  const buildInfo = await utils.getBuildInfo(
+  const buildInfo = await getBuildInfo(
     {
       ...options,
       contract: fromBuffer(collectionResult.contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/buy/token.ts
@@ -1,44 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  contract: string;
-  tokenId: string;
-}
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.1/build/utils";
+import {
+  BuyTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/buy/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const excludeFlaggedTokens = options.excludeFlaggedTokens
-    ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
-    : "";
-
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-      AND tokens.token_id = $/tokenId/
-      ${excludeFlaggedTokens}
-    `,
-    {
-      contract: toBuffer(options.contract),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "buy");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  return builder?.build(
-    { ...buildInfo.params, tokenId: options.tokenId, amount: options.quantity },
-    Sdk.SeaportV11.Order
-  );
+  const builder = new BuyTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV11.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/sell/token.ts
@@ -1,37 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.1/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  tokenId: string;
-}
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.1/build/utils";
+import {
+  SellTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/sell/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-        AND tokens.token_id = $/tokenId/
-    `,
-    {
-      contract: toBuffer(options.contract!),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "sell");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  const tokenId = options.tokenId;
-
-  return builder?.build({ ...buildInfo.params, tokenId }, Sdk.SeaportV11.Order);
+  const builder = new SellTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV11.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/utils.ts
@@ -7,7 +7,6 @@ import { baseProvider } from "@/common/provider";
 import { bn, fromBuffer, now } from "@/common/utils";
 import { config } from "@/config/index";
 import * as marketplaceFees from "@/utils/marketplace-fees";
-import { logger } from "@/common/logger";
 
 export interface BaseOrderBuildOptions {
   maker: string;
@@ -101,7 +100,6 @@ export const getBuildInfo = async (
   let totalFees = bn(0);
 
   // Include royalties
-  let totalBps = 0;
   if (options.automatedRoyalties) {
     const royalties: { bps: number; recipient: string }[] =
       (options.orderbook === "opensea"
@@ -119,7 +117,6 @@ export const getBuildInfo = async (
         const bps = Math.min(royaltyBpsToPay, r.bps);
         if (bps > 0) {
           royaltyBpsToPay -= bps;
-          totalBps += bps;
 
           const fee = bn(bps).mul(options.weiPrice).div(10000).toString();
           buildParams.fees!.push({
@@ -145,22 +142,7 @@ export const getBuildInfo = async (
     if (collectionResult.marketplace_fees?.opensea == null) {
       openseaMarketplaceFees = await marketplaceFees.getCollectionOpenseaFees(
         collection,
-        fromBuffer(collectionResult.contract),
-        totalBps
-      );
-
-      logger.info(
-        "getCollectionOpenseaFees",
-        `From api. collection=${collection}, openseaMarketplaceFees=${JSON.stringify(
-          openseaMarketplaceFees
-        )}`
-      );
-    } else {
-      logger.info(
-        "getCollectionOpenseaFees",
-        `From db. collection=${collection}, openseaMarketplaceFees=${JSON.stringify(
-          openseaMarketplaceFees
-        )}`
+        fromBuffer(collectionResult.contract)
       );
     }
 
@@ -168,9 +150,6 @@ export const getBuildInfo = async (
       options.fee.push(openseaMarketplaceFee.bps);
       options.feeRecipient.push(openseaMarketplaceFee.recipient);
     }
-
-    // Refresh opensea fees
-    await marketplaceFees.refreshCollectionOpenseaFeesAsync(collection);
   }
 
   if (options.fee && options.feeRecipient) {

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/build/utils.ts
@@ -1,43 +1,17 @@
 import { AddressZero } from "@ethersproject/constants";
 import * as Sdk from "@reservoir0x/sdk";
-import { generateSourceBytes, getRandomBytes } from "@reservoir0x/sdk/dist/utils";
+import { getRandomBytes } from "@reservoir0x/sdk/dist/utils";
 
 import { redb } from "@/common/db";
 import { baseProvider } from "@/common/provider";
 import { bn, fromBuffer, now } from "@/common/utils";
 import { config } from "@/config/index";
 import * as marketplaceFees from "@/utils/marketplace-fees";
-
-export interface BaseOrderBuildOptions {
-  maker: string;
-  contract?: string;
-  weiPrice: string;
-  orderbook: "opensea" | "reservoir";
-  orderType?: Sdk.SeaportBase.Types.OrderType;
-  currency?: string;
-  quantity?: number;
-  nonce?: string;
-  fee?: number[];
-  feeRecipient?: string[];
-  listingTime?: number;
-  expirationTime?: number;
-  salt?: string;
-  automatedRoyalties?: boolean;
-  royaltyBps?: number;
-  excludeFlaggedTokens?: boolean;
-  source?: string;
-}
-
-type OrderBuildInfo = {
-  params: Sdk.SeaportBase.BaseBuildParams;
-  kind: "erc721" | "erc1155";
-};
-
-export const padSourceToSalt = (source: string, salt: string) => {
-  const sourceHash = generateSourceBytes(source);
-  const saltHex = bn(salt)._hex.slice(6);
-  return bn(`0x${sourceHash}${saltHex}`).toString();
-};
+import {
+  BaseOrderBuildOptions,
+  OrderBuildInfo,
+  padSourceToSalt,
+} from "@/orderbook/orders/seaport-base/build/utils";
 
 export const getBuildInfo = async (
   options: BaseOrderBuildOptions,

--- a/packages/indexer/src/orderbook/orders/seaport-v1.1/index.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.1/index.ts
@@ -72,7 +72,7 @@ export const save = async (
   const orderValues: DbOrder[] = [];
 
   const arweaveData: {
-    order: Sdk.SeaportV11.Order;
+    order: Sdk.SeaportBase.IOrder;
     schemaHash?: string;
     source?: string;
   }[] = [];

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/attribute.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/attribute.ts
@@ -4,10 +4,11 @@ import { BigNumberish } from "@ethersproject/bignumber";
 import { redb } from "@/common/db";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.4/build/utils";
+import { BaseOrderBuildOptions } from "@/orderbook/orders/seaport-base/build/utils";
 import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   // TODO: refactor
   // The following combinations are possible:
   // - collection + attributes
@@ -56,7 +57,7 @@ export const build = async (options: BuildOrderOptions) => {
       throw new Error("Attribute has too many items");
     }
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(attributeResult.contract),
@@ -129,7 +130,7 @@ export const build = async (options: BuildOrderOptions) => {
       }
     );
 
-    const buildInfo = await utils.getBuildInfo(
+    const buildInfo = await getBuildInfo(
       {
         ...options,
         contract: fromBuffer(tokens[0].contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/collection.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/collection.ts
@@ -5,12 +5,13 @@ import { idb } from "@/common/db";
 import { redis } from "@/common/redis";
 import { fromBuffer } from "@/common/utils";
 import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.4/build/utils";
+import { BaseOrderBuildOptions } from "@/orderbook/orders/seaport-base/build/utils";
 import { generateSchemaHash } from "@/orderbook/orders/utils";
 import * as OpenSeaApi from "@/jobs/orderbook/post-order-external/api/opensea";
 import { Tokens } from "@/models/tokens";
 
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
+interface BuildOrderOptions extends BaseOrderBuildOptions {
   collection: string;
 }
 
@@ -36,7 +37,7 @@ export const build = async (options: BuildOrderOptions) => {
     throw new Error("Collection has too many tokens");
   }
 
-  const buildInfo = await utils.getBuildInfo(
+  const buildInfo = await getBuildInfo(
     {
       ...options,
       contract: fromBuffer(collectionResult.contract),

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/buy/token.ts
@@ -1,44 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  contract: string;
-  tokenId: string;
-}
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.4/build/utils";
+import {
+  BuyTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/buy/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const excludeFlaggedTokens = options.excludeFlaggedTokens
-    ? "AND (tokens.is_flagged = 0 OR tokens.is_flagged IS NULL)"
-    : "";
-
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-      AND tokens.token_id = $/tokenId/
-      ${excludeFlaggedTokens}
-    `,
-    {
-      contract: toBuffer(options.contract),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "buy");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  const tokenId = options.tokenId;
-  const amount = options.quantity;
-
-  return builder?.build({ ...buildInfo.params, tokenId, amount }, Sdk.SeaportV14.Order);
+  const builder = new BuyTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV14.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/sell/token.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/sell/token.ts
@@ -1,37 +1,12 @@
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
-import { toBuffer } from "@/common/utils";
-import { config } from "@/config/index";
-import * as utils from "@/orderbook/orders/seaport-v1.4/build/utils";
-
-interface BuildOrderOptions extends utils.BaseOrderBuildOptions {
-  tokenId: string;
-}
+import { getBuildInfo } from "@/orderbook/orders/seaport-v1.4/build/utils";
+import {
+  SellTokenBuilderBase,
+  BuildOrderOptions,
+} from "@/orderbook/orders/seaport-base/build/sell/token";
 
 export const build = async (options: BuildOrderOptions) => {
-  const collectionResult = await redb.oneOrNone(
-    `
-      SELECT
-        tokens.collection_id
-      FROM tokens
-      WHERE tokens.contract = $/contract/
-        AND tokens.token_id = $/tokenId/
-    `,
-    {
-      contract: toBuffer(options.contract!),
-      tokenId: options.tokenId,
-    }
-  );
-  if (!collectionResult) {
-    throw new Error("Could not retrieve token's collection");
-  }
-
-  const buildInfo = await utils.getBuildInfo(options, collectionResult.collection_id, "sell");
-
-  const builder = new Sdk.SeaportBase.Builders.SingleToken(config.chainId);
-
-  const tokenId = options.tokenId;
-
-  return builder?.build({ ...buildInfo.params, tokenId }, Sdk.SeaportV14.Order);
+  const builder = new SellTokenBuilderBase(getBuildInfo);
+  return await builder.build(options, Sdk.SeaportV14.Order);
 };

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/build/utils.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/build/utils.ts
@@ -1,45 +1,17 @@
 import { AddressZero } from "@ethersproject/constants";
 import * as Sdk from "@reservoir0x/sdk";
-import { generateSourceBytes, getRandomBytes } from "@reservoir0x/sdk/dist/utils";
+import { getRandomBytes } from "@reservoir0x/sdk/dist/utils";
 
 import { redb } from "@/common/db";
 import { baseProvider } from "@/common/provider";
 import { bn, fromBuffer, now } from "@/common/utils";
 import { config } from "@/config/index";
 import * as marketplaceFees from "@/utils/marketplace-fees";
-
-export interface BaseOrderBuildOptions {
-  maker: string;
-  contract?: string;
-  weiPrice: string;
-  orderbook: "opensea" | "reservoir";
-  useOffChainCancellation?: boolean;
-  replaceOrderId?: string;
-  orderType?: Sdk.SeaportBase.Types.OrderType;
-  currency?: string;
-  quantity?: number;
-  nonce?: string;
-  fee?: number[];
-  feeRecipient?: string[];
-  listingTime?: number;
-  expirationTime?: number;
-  salt?: string;
-  automatedRoyalties?: boolean;
-  royaltyBps?: number;
-  excludeFlaggedTokens?: boolean;
-  source?: string;
-}
-
-type OrderBuildInfo = {
-  params: Sdk.SeaportBase.BaseBuildParams;
-  kind: "erc721" | "erc1155";
-};
-
-export const padSourceToSalt = (source: string, salt: string) => {
-  const sourceHash = generateSourceBytes(source);
-  const saltHex = bn(salt)._hex.slice(6);
-  return bn(`0x${sourceHash}${saltHex}`).toString();
-};
+import {
+  BaseOrderBuildOptions,
+  OrderBuildInfo,
+  padSourceToSalt,
+} from "@/orderbook/orders/seaport-base/build/utils";
 
 export const getBuildInfo = async (
   options: BaseOrderBuildOptions,

--- a/packages/indexer/src/orderbook/orders/seaport-v1.4/index.ts
+++ b/packages/indexer/src/orderbook/orders/seaport-v1.4/index.ts
@@ -829,7 +829,7 @@ export const save = async (
     );
 
     if (relayToArweave) {
-      await arweaveRelay.addPendingOrdersSeaportV14(arweaveData);
+      await arweaveRelay.addPendingOrdersSeaport(arweaveData);
     }
   }
 

--- a/packages/indexer/src/sync/events/data/alienswap.ts
+++ b/packages/indexer/src/sync/events/data/alienswap.ts
@@ -1,0 +1,111 @@
+import { Interface } from "@ethersproject/abi";
+import { Alienswap } from "@reservoir0x/sdk";
+
+import { config } from "@/config/index";
+import { EventData } from "@/events-sync/data";
+
+export const orderCancelled: EventData = {
+  kind: "seaport",
+  subKind: "alienswap-order-cancelled",
+  addresses: { [Alienswap.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0x6bacc01dbe442496068f7d234edd811f1a5f833243e0aec824f86ab861f3c90d",
+  numTopics: 3,
+  abi: new Interface([
+    `event OrderCancelled(
+      bytes32 orderHash,
+      address indexed offerer,
+      address indexed zone
+    )`,
+  ]),
+};
+
+export const orderFulfilled: EventData = {
+  kind: "seaport",
+  subKind: "alienswap-order-filled",
+  addresses: { [Alienswap.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31",
+  numTopics: 3,
+  abi: new Interface([
+    `event OrderFulfilled(
+      bytes32 orderHash,
+      address indexed offerer,
+      address indexed zone,
+      address recipient,
+      (
+        uint8 itemType,
+        address token,
+        uint256 identifier,
+        uint256 amount
+      )[] offer,
+      (
+        uint8 itemType,
+        address token,
+        uint256 identifier,
+        uint256 amount,
+        address recipient
+      )[] consideration
+    )`,
+  ]),
+};
+
+export const ordersMatched: EventData = {
+  kind: "seaport",
+  subKind: "alienswap-orders-matched",
+  addresses: { [Alienswap.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0x4b9f2d36e1b4c93de62cc077b00b1a91d84b6c31b4a14e012718dcca230689e7",
+  numTopics: 1,
+  abi: new Interface([`event OrdersMatched(bytes32[] orderHashes)`]),
+};
+
+export const counterIncremented: EventData = {
+  kind: "seaport",
+  subKind: "alienswap-counter-incremented",
+  addresses: { [Alienswap.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0x721c20121297512b72821b97f5326877ea8ecf4bb9948fea5bfcb6453074d37f",
+  numTopics: 2,
+  abi: new Interface([
+    `event CounterIncremented(
+      uint256 newCounter,
+      address indexed offerer
+    )`,
+  ]),
+};
+
+export const orderValidated: EventData = {
+  kind: "seaport",
+  subKind: "alienswap-order-validated",
+  addresses: { [Alienswap.Addresses.Exchange[config.chainId]?.toLowerCase()]: true },
+  topic: "0xf280791efe782edcf06ce15c8f4dff17601db3b88eb3805a0db7d77faf757f04",
+  numTopics: 1,
+  abi: new Interface([
+    `event OrderValidated(
+      bytes32 orderHash,
+      (
+        address offerer,
+        address zone,
+        (
+          uint8 itemType,
+          address token,
+          uint256 identifierOrCriteria,
+          uint256 startAmount,
+          uint256 endAmount
+        )[] offer,
+        (
+          uint8 itemType,
+          address token,
+          uint256 identifierOrCriteria,
+          uint256 startAmount,
+          uint256 endAmount,
+          address recipient
+        )[] consideration,
+        uint8 orderType,
+        uint256 startTime,
+        uint256 endTime,
+        bytes32 zoneHash,
+        uint256 salt,
+        bytes32 conduitKey,
+        uint256 totalOriginalConsiderationItems
+      ) orderParameters
+    )`,
+  ]),
+};

--- a/packages/indexer/src/sync/events/data/index.ts
+++ b/packages/indexer/src/sync/events/data/index.ts
@@ -23,6 +23,7 @@ import * as quixotic from "@/events-sync/data/quixotic";
 import * as rarible from "@/events-sync/data/rarible";
 import * as seaport from "@/events-sync/data/seaport";
 import * as seaportV14 from "@/events-sync/data/seaport-v1.4";
+import * as alienswap from "@/events-sync/data/alienswap";
 import * as sudoswap from "@/events-sync/data/sudoswap";
 import * as superrare from "@/events-sync/data/superrare";
 import * as tofu from "@/events-sync/data/tofu";
@@ -114,6 +115,11 @@ export type EventSubKind =
   | "seaport-v1.4-orders-matched"
   | "seaport-v1.4-counter-incremented"
   | "seaport-v1.4-order-validated"
+  | "alienswap-order-cancelled"
+  | "alienswap-order-filled"
+  | "alienswap-orders-matched"
+  | "alienswap-counter-incremented"
+  | "alienswap-order-validated"
   | "rarible-match"
   | "rarible-cancel"
   | "rarible-buy-v1"
@@ -233,6 +239,11 @@ const allEventData = [
   seaportV14.orderFulfilled,
   seaportV14.ordersMatched,
   seaportV14.orderValidated,
+  alienswap.counterIncremented,
+  alienswap.orderCancelled,
+  alienswap.orderFulfilled,
+  alienswap.ordersMatched,
+  alienswap.orderValidated,
   wyvernV2.ordersMatched,
   wyvernV23.ordersMatched,
   zeroExV4.erc721OrderCancelled,

--- a/packages/indexer/src/sync/events/index.ts
+++ b/packages/indexer/src/sync/events/index.ts
@@ -303,7 +303,9 @@ export const syncEvents = async (
     }
 
     const limit = pLimit(32);
-    await Promise.all(blocksToFetch.map((block) => limit(() => syncEventsUtils.fetchBlock(block))));
+    await Promise.all(
+      blocksToFetch.map((block) => limit(() => syncEventsUtils.fetchBlock(block, true)))
+    );
   }
 
   logger.info(

--- a/packages/indexer/src/sync/events/index.ts
+++ b/packages/indexer/src/sync/events/index.ts
@@ -459,7 +459,10 @@ export const syncEvents = async (
 
       // Log blocks for which no logs were fetched from the RPC provider
       if (!_.isEmpty(blockNumbersArray)) {
-        logger.warn("sync-events", `No logs fetched for ${JSON.stringify(blockNumbersArray)}`);
+        logger.warn(
+          "sync-events",
+          `[${fromBlock}, ${toBlock}] No logs fetched for ${JSON.stringify(blockNumbersArray)}`
+        );
       }
 
       await blockCheck.addBulk(blocksToCheck);

--- a/packages/indexer/src/sync/events/index.ts
+++ b/packages/indexer/src/sync/events/index.ts
@@ -440,7 +440,7 @@ export const syncEvents = async (
       }
 
       const blocksToCheck: BlocksToCheck[] = [];
-      let blockNumbersArray = _.range(fromBlock, toBlock + 1);
+      let blockNumbersArray = _.range(fromBlock, toBlock);
 
       // Put all fetched blocks on a delayed queue
       [...blocksSet.values()].map(async (blockData) => {

--- a/packages/sdk/src/alienswap/abis/Exchange.json
+++ b/packages/sdk/src/alienswap/abis/Exchange.json
@@ -1,0 +1,2215 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "conduitController",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "BadContractSignature", "type": "error" },
+  { "inputs": [], "name": "BadFraction", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "BadReturnValueFromERC20OnTransfer",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "uint8", "name": "v", "type": "uint8" }],
+    "name": "BadSignatureV",
+    "type": "error"
+  },
+  { "inputs": [], "name": "CannotCancelOrder", "type": "error" },
+  {
+    "inputs": [],
+    "name": "ConsiderationCriteriaResolverOutOfRange",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConsiderationLengthNotEqualToTotalOriginal",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "orderIndex", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "considerationIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shortfallAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConsiderationNotMet",
+    "type": "error"
+  },
+  { "inputs": [], "name": "CriteriaNotEnabledForItem", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      {
+        "internalType": "uint256[]",
+        "name": "identifiers",
+        "type": "uint256[]"
+      },
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
+    "name": "ERC1155BatchTransferGenericFailure",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InexactFraction", "type": "error" },
+  { "inputs": [], "name": "InsufficientNativeTokensSupplied", "type": "error" },
+  { "inputs": [], "name": "Invalid1155BatchTransferEncoding", "type": "error" },
+  {
+    "inputs": [],
+    "name": "InvalidBasicOrderParameterEncoding",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "conduit", "type": "address" }],
+    "name": "InvalidCallToConduit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "conduitKey", "type": "bytes32" },
+      { "internalType": "address", "name": "conduit", "type": "address" }
+    ],
+    "name": "InvalidConduit",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "name": "InvalidContractOrder",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "amount", "type": "uint256" }],
+    "name": "InvalidERC721TransferAmount",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidFulfillmentComponentData", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "value", "type": "uint256" }],
+    "name": "InvalidMsgValue",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidNativeOfferItem", "type": "error" },
+  { "inputs": [], "name": "InvalidProof", "type": "error" },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "name": "InvalidRestrictedOrder",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidSignature", "type": "error" },
+  { "inputs": [], "name": "InvalidSigner", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "startTime", "type": "uint256" },
+      { "internalType": "uint256", "name": "endTime", "type": "uint256" }
+    ],
+    "name": "InvalidTime",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "fulfillmentIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "MismatchedFulfillmentOfferAndConsiderationComponents",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "enum Side", "name": "side", "type": "uint8" }],
+    "name": "MissingFulfillmentComponentOnAggregation",
+    "type": "error"
+  },
+  { "inputs": [], "name": "MissingItemAmount", "type": "error" },
+  {
+    "inputs": [],
+    "name": "MissingOriginalConsiderationItems",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "NativeTokenTransferGenericFailure",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "NoContract",
+    "type": "error"
+  },
+  { "inputs": [], "name": "NoReentrantCalls", "type": "error" },
+  { "inputs": [], "name": "NoSpecifiedOrdersAvailable", "type": "error" },
+  {
+    "inputs": [],
+    "name": "OfferAndConsiderationRequiredOnFulfillment",
+    "type": "error"
+  },
+  { "inputs": [], "name": "OfferCriteriaResolverOutOfRange", "type": "error" },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "name": "OrderAlreadyFilled",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "enum Side", "name": "side", "type": "uint8" }],
+    "name": "OrderCriteriaResolverOutOfRange",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "name": "OrderIsCancelled",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "name": "OrderPartiallyFilled",
+    "type": "error"
+  },
+  { "inputs": [], "name": "PartialFillsNotEnabledForOrder", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "identifier", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "TokenTransferGenericFailure",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "orderIndex", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "considerationIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnresolvedConsiderationCriteria",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "orderIndex", "type": "uint256" },
+      { "internalType": "uint256", "name": "offerIndex", "type": "uint256" }
+    ],
+    "name": "UnresolvedOfferCriteria",
+    "type": "error"
+  },
+  { "inputs": [], "name": "UnusedItemParameters", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newCounter",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "offerer",
+        "type": "address"
+      }
+    ],
+    "name": "CounterIncremented",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "offerer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "zone",
+        "type": "address"
+      }
+    ],
+    "name": "OrderCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "offerer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "zone",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum ItemType",
+            "name": "itemType",
+            "type": "uint8"
+          },
+          { "internalType": "address", "name": "token", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" }
+        ],
+        "indexed": false,
+        "internalType": "struct SpentItem[]",
+        "name": "offer",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum ItemType",
+            "name": "itemType",
+            "type": "uint8"
+          },
+          { "internalType": "address", "name": "token", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "internalType": "address payable",
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ReceivedItem[]",
+        "name": "consideration",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "OrderFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "address", "name": "zone", "type": "address" },
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifierOrCriteria",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endAmount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OfferItem[]",
+            "name": "offer",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifierOrCriteria",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ConsiderationItem[]",
+            "name": "consideration",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum OrderType",
+            "name": "orderType",
+            "type": "uint8"
+          },
+          { "internalType": "uint256", "name": "startTime", "type": "uint256" },
+          { "internalType": "uint256", "name": "endTime", "type": "uint256" },
+          { "internalType": "bytes32", "name": "zoneHash", "type": "bytes32" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          {
+            "internalType": "bytes32",
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalOriginalConsiderationItems",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct OrderParameters",
+        "name": "orderParameters",
+        "type": "tuple"
+      }
+    ],
+    "name": "OrderValidated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "orderHashes",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "OrdersMatched",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "address", "name": "zone", "type": "address" },
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifierOrCriteria",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endAmount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OfferItem[]",
+            "name": "offer",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifierOrCriteria",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ConsiderationItem[]",
+            "name": "consideration",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum OrderType",
+            "name": "orderType",
+            "type": "uint8"
+          },
+          { "internalType": "uint256", "name": "startTime", "type": "uint256" },
+          { "internalType": "uint256", "name": "endTime", "type": "uint256" },
+          { "internalType": "bytes32", "name": "zoneHash", "type": "bytes32" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          {
+            "internalType": "bytes32",
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          { "internalType": "uint256", "name": "counter", "type": "uint256" }
+        ],
+        "internalType": "struct OrderComponents[]",
+        "name": "orders",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "cancel",
+    "outputs": [{ "internalType": "bool", "name": "cancelled", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "uint120", "name": "numerator", "type": "uint120" },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" },
+          { "internalType": "bytes", "name": "extraData", "type": "bytes" }
+        ],
+        "internalType": "struct AdvancedOrder",
+        "name": "advancedOrder",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "enum Side", "name": "side", "type": "uint8" },
+          { "internalType": "uint256", "name": "index", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "criteriaProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct CriteriaResolver[]",
+        "name": "criteriaResolvers",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "fulfillerConduitKey",
+        "type": "bytes32"
+      },
+      { "internalType": "address", "name": "recipient", "type": "address" }
+    ],
+    "name": "fulfillAdvancedOrder",
+    "outputs": [{ "internalType": "bool", "name": "fulfilled", "type": "bool" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "uint120", "name": "numerator", "type": "uint120" },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" },
+          { "internalType": "bytes", "name": "extraData", "type": "bytes" }
+        ],
+        "internalType": "struct AdvancedOrder[]",
+        "name": "",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "enum Side", "name": "side", "type": "uint8" },
+          { "internalType": "uint256", "name": "index", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "criteriaProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct CriteriaResolver[]",
+        "name": "",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "itemIndex", "type": "uint256" }
+        ],
+        "internalType": "struct FulfillmentComponent[][]",
+        "name": "",
+        "type": "tuple[][]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "itemIndex", "type": "uint256" }
+        ],
+        "internalType": "struct FulfillmentComponent[][]",
+        "name": "",
+        "type": "tuple[][]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "fulfillerConduitKey",
+        "type": "bytes32"
+      },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "maximumFulfilled",
+        "type": "uint256"
+      }
+    ],
+    "name": "fulfillAvailableAdvancedOrders",
+    "outputs": [
+      { "internalType": "bool[]", "name": "", "type": "bool[]" },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifier",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ReceivedItem",
+            "name": "item",
+            "type": "tuple"
+          },
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "bytes32", "name": "conduitKey", "type": "bytes32" }
+        ],
+        "internalType": "struct Execution[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" }
+        ],
+        "internalType": "struct Order[]",
+        "name": "",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "itemIndex", "type": "uint256" }
+        ],
+        "internalType": "struct FulfillmentComponent[][]",
+        "name": "",
+        "type": "tuple[][]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "itemIndex", "type": "uint256" }
+        ],
+        "internalType": "struct FulfillmentComponent[][]",
+        "name": "",
+        "type": "tuple[][]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "fulfillerConduitKey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maximumFulfilled",
+        "type": "uint256"
+      }
+    ],
+    "name": "fulfillAvailableOrders",
+    "outputs": [
+      { "internalType": "bool[]", "name": "", "type": "bool[]" },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifier",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ReceivedItem",
+            "name": "item",
+            "type": "tuple"
+          },
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "bytes32", "name": "conduitKey", "type": "bytes32" }
+        ],
+        "internalType": "struct Execution[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "considerationToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "considerationIdentifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "considerationAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address payable",
+            "name": "offerer",
+            "type": "address"
+          },
+          { "internalType": "address", "name": "zone", "type": "address" },
+          {
+            "internalType": "address",
+            "name": "offerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offerIdentifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum BasicOrderType",
+            "name": "basicOrderType",
+            "type": "uint8"
+          },
+          { "internalType": "uint256", "name": "startTime", "type": "uint256" },
+          { "internalType": "uint256", "name": "endTime", "type": "uint256" },
+          { "internalType": "bytes32", "name": "zoneHash", "type": "bytes32" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          {
+            "internalType": "bytes32",
+            "name": "offererConduitKey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "fulfillerConduitKey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalOriginalAdditionalRecipients",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct AdditionalRecipient[]",
+            "name": "additionalRecipients",
+            "type": "tuple[]"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" }
+        ],
+        "internalType": "struct BasicOrderParameters",
+        "name": "parameters",
+        "type": "tuple"
+      }
+    ],
+    "name": "fulfillBasicOrder",
+    "outputs": [{ "internalType": "bool", "name": "fulfilled", "type": "bool" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "considerationToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "considerationIdentifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "considerationAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address payable",
+            "name": "offerer",
+            "type": "address"
+          },
+          { "internalType": "address", "name": "zone", "type": "address" },
+          {
+            "internalType": "address",
+            "name": "offerToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offerIdentifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "offerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum BasicOrderType",
+            "name": "basicOrderType",
+            "type": "uint8"
+          },
+          { "internalType": "uint256", "name": "startTime", "type": "uint256" },
+          { "internalType": "uint256", "name": "endTime", "type": "uint256" },
+          { "internalType": "bytes32", "name": "zoneHash", "type": "bytes32" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          {
+            "internalType": "bytes32",
+            "name": "offererConduitKey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "fulfillerConduitKey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalOriginalAdditionalRecipients",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct AdditionalRecipient[]",
+            "name": "additionalRecipients",
+            "type": "tuple[]"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" }
+        ],
+        "internalType": "struct BasicOrderParameters",
+        "name": "parameters",
+        "type": "tuple"
+      }
+    ],
+    "name": "fulfillBasicOrder_efficient_6GL6yc",
+    "outputs": [{ "internalType": "bool", "name": "fulfilled", "type": "bool" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" }
+        ],
+        "internalType": "struct Order",
+        "name": "",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "fulfillerConduitKey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "fulfillOrder",
+    "outputs": [{ "internalType": "bool", "name": "fulfilled", "type": "bool" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "contractOfferer",
+        "type": "address"
+      }
+    ],
+    "name": "getContractOffererNonce",
+    "outputs": [{ "internalType": "uint256", "name": "nonce", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "offerer", "type": "address" }],
+    "name": "getCounter",
+    "outputs": [{ "internalType": "uint256", "name": "counter", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "address", "name": "zone", "type": "address" },
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifierOrCriteria",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endAmount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OfferItem[]",
+            "name": "offer",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifierOrCriteria",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endAmount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ConsiderationItem[]",
+            "name": "consideration",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "enum OrderType",
+            "name": "orderType",
+            "type": "uint8"
+          },
+          { "internalType": "uint256", "name": "startTime", "type": "uint256" },
+          { "internalType": "uint256", "name": "endTime", "type": "uint256" },
+          { "internalType": "bytes32", "name": "zoneHash", "type": "bytes32" },
+          { "internalType": "uint256", "name": "salt", "type": "uint256" },
+          {
+            "internalType": "bytes32",
+            "name": "conduitKey",
+            "type": "bytes32"
+          },
+          { "internalType": "uint256", "name": "counter", "type": "uint256" }
+        ],
+        "internalType": "struct OrderComponents",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "name": "getOrderHash",
+    "outputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "orderHash", "type": "bytes32" }],
+    "name": "getOrderStatus",
+    "outputs": [
+      { "internalType": "bool", "name": "isValidated", "type": "bool" },
+      { "internalType": "bool", "name": "isCancelled", "type": "bool" },
+      { "internalType": "uint256", "name": "totalFilled", "type": "uint256" },
+      { "internalType": "uint256", "name": "totalSize", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "incrementCounter",
+    "outputs": [{ "internalType": "uint256", "name": "newCounter", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "information",
+    "outputs": [
+      { "internalType": "string", "name": "version", "type": "string" },
+      {
+        "internalType": "bytes32",
+        "name": "domainSeparator",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "conduitController",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "uint120", "name": "numerator", "type": "uint120" },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" },
+          { "internalType": "bytes", "name": "extraData", "type": "bytes" }
+        ],
+        "internalType": "struct AdvancedOrder[]",
+        "name": "advancedOrders",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          { "internalType": "enum Side", "name": "side", "type": "uint8" },
+          { "internalType": "uint256", "name": "index", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "criteriaProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct CriteriaResolver[]",
+        "name": "criteriaResolvers",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "orderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "itemIndex",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct FulfillmentComponent[]",
+            "name": "offerComponents",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "orderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "itemIndex",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct FulfillmentComponent[]",
+            "name": "considerationComponents",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct Fulfillment[]",
+        "name": "fulfillments",
+        "type": "tuple[]"
+      },
+      { "internalType": "address", "name": "recipient", "type": "address" }
+    ],
+    "name": "matchAdvancedOrders",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifier",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ReceivedItem",
+            "name": "item",
+            "type": "tuple"
+          },
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "bytes32", "name": "conduitKey", "type": "bytes32" }
+        ],
+        "internalType": "struct Execution[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" }
+        ],
+        "internalType": "struct Order[]",
+        "name": "",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "orderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "itemIndex",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct FulfillmentComponent[]",
+            "name": "offerComponents",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "orderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "itemIndex",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct FulfillmentComponent[]",
+            "name": "considerationComponents",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct Fulfillment[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "matchOrders",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "enum ItemType",
+                "name": "itemType",
+                "type": "uint8"
+              },
+              { "internalType": "address", "name": "token", "type": "address" },
+              {
+                "internalType": "uint256",
+                "name": "identifier",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct ReceivedItem",
+            "name": "item",
+            "type": "tuple"
+          },
+          { "internalType": "address", "name": "offerer", "type": "address" },
+          { "internalType": "bytes32", "name": "conduitKey", "type": "bytes32" }
+        ],
+        "internalType": "struct Execution[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              { "internalType": "address", "name": "zone", "type": "address" },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address payable",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              { "internalType": "uint256", "name": "salt", "type": "uint256" },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          { "internalType": "bytes", "name": "signature", "type": "bytes" }
+        ],
+        "internalType": "struct Order[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "validate",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/packages/sdk/src/alienswap/addresses.ts
+++ b/packages/sdk/src/alienswap/addresses.ts
@@ -1,0 +1,11 @@
+import { ChainIdToAddress, Network } from "../utils";
+
+export const Exchange: ChainIdToAddress = {
+  [Network.Ethereum]: "0x7374FE94e34c209616cEc0610212DE13151D222f",
+  [Network.EthereumGoerli]: "0x7374FE94e34c209616cEc0610212DE13151D222f",
+};
+
+export const OpenseaConduitKey: ChainIdToAddress = {
+  [Network.Ethereum]: "0x7e727520b29773e7f23a8665649197aaf064cef1000000000000000000000001",
+  [Network.EthereumGoerli]: "0x7e727520b29773e7f23a8665649197aaf064cef1000000000000000000000001",
+};

--- a/packages/sdk/src/alienswap/exchange.ts
+++ b/packages/sdk/src/alienswap/exchange.ts
@@ -1,30 +1,25 @@
+import { Exchange as SeaportV14Exchange } from "../seaport-v1.4/exchange";
 import { Contract } from "@ethersproject/contracts";
-import { HashZero } from "@ethersproject/constants";
 import * as Addresses from "./addresses";
 import ExchangeAbi from "./abis/Exchange.json";
-import { SeaportBaseExchange } from "../seaport-base/exchange";
+import { AddressZero } from "@ethersproject/constants";
 import { IOrder } from "../seaport-base/order";
 
-export class Exchange extends SeaportBaseExchange {
+export class Exchange extends SeaportV14Exchange {
+  protected exchangeAddress: string;
+  protected cancellationZoneAddress: string = AddressZero;
   public contract: Contract;
 
   constructor(chainId: number) {
     super(chainId);
-    this.contract = new Contract(Addresses.Exchange[chainId], ExchangeAbi);
-  }
-
-  // --- Derive conduit from key ---
-
-  public deriveConduit(conduitKey: string) {
-    return conduitKey === HashZero
-      ? Addresses.Exchange[this.chainId]
-      : this.conduitController.deriveConduit(conduitKey);
+    this.exchangeAddress = Addresses.Exchange[chainId];
+    this.contract = new Contract(this.exchangeAddress, ExchangeAbi);
   }
 
   // --- Get extra data ---
-
+  // not support off chain cancellation at present
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected requiresExtraData(_order_: IOrder): boolean {
+  public requiresExtraData(_order_: IOrder): boolean {
     return false;
   }
 

--- a/packages/sdk/src/alienswap/index.ts
+++ b/packages/sdk/src/alienswap/index.ts
@@ -1,0 +1,6 @@
+import * as Addresses from "./addresses";
+import { Exchange } from "./exchange";
+import { Order } from "./order";
+
+// TODO: @Joey, use real addresses and abi
+export { Addresses, Exchange, Order };

--- a/packages/sdk/src/alienswap/order.ts
+++ b/packages/sdk/src/alienswap/order.ts
@@ -1,0 +1,439 @@
+import { Interface } from "@ethersproject/abi";
+import { Provider } from "@ethersproject/abstract-provider";
+import { TypedDataSigner } from "@ethersproject/abstract-signer";
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
+import { Contract } from "@ethersproject/contracts";
+import { _TypedDataEncoder } from "@ethersproject/hash";
+import { keccak256 as solidityKeccak256 } from "@ethersproject/solidity";
+import { recoverAddress } from "@ethersproject/transactions";
+import { verifyTypedData } from "@ethersproject/wallet";
+
+import * as Addresses from "./addresses";
+import { Builders } from "../seaport-base/builders";
+import { BaseBuilder, BaseOrderInfo } from "../seaport-base/builders/base";
+import * as Types from "../seaport-base/types";
+import { IOrder, ORDER_EIP712_TYPES, SeaportOrderKind } from "../seaport-base/order";
+import * as Common from "../common";
+import { bn, getCurrentTimestamp, lc, n, s } from "../utils";
+
+import { Exchange } from "./exchange";
+
+export class Order implements IOrder {
+  public chainId: number;
+  public params: Types.OrderComponents;
+
+  constructor(chainId: number, params: Types.OrderComponents) {
+    this.chainId = chainId;
+
+    try {
+      this.params = normalize(params);
+    } catch {
+      throw new Error("Invalid params");
+    }
+
+    // Detect kind
+    if (!params.kind) {
+      this.params.kind = this.detectKind();
+    }
+
+    // Fix signature
+    this.fixSignature();
+  }
+
+  public hash() {
+    return _TypedDataEncoder.hashStruct("OrderComponents", ORDER_EIP712_TYPES, this.params);
+  }
+
+  public async sign(signer: TypedDataSigner) {
+    const signature = await signer._signTypedData(
+      EIP712_DOMAIN(this.chainId),
+      ORDER_EIP712_TYPES,
+      this.params
+    );
+
+    this.params = {
+      ...this.params,
+      signature,
+    };
+  }
+
+  public getSignatureData() {
+    return {
+      signatureKind: "eip712",
+      domain: EIP712_DOMAIN(this.chainId),
+      types: ORDER_EIP712_TYPES,
+      value: this.params,
+    };
+  }
+
+  public async checkSignature(provider?: Provider) {
+    const signature = this.params.signature!;
+
+    try {
+      // Remove the `0x` prefix and count bytes not characters
+      const actualSignatureLength = (signature.length - 2) / 2;
+
+      // https://github.com/ProjectOpenSea/seaport/blob/4f2210b59aefa119769a154a12e55d9b77ca64eb/reference/lib/ReferenceVerifiers.sol#L126-L133
+      const isBulkSignature =
+        actualSignatureLength < 837 &&
+        actualSignatureLength > 98 &&
+        (actualSignatureLength - 67) % 32 < 2;
+      if (isBulkSignature) {
+        // https://github.com/ProjectOpenSea/seaport/blob/4f2210b59aefa119769a154a12e55d9b77ca64eb/reference/lib/ReferenceVerifiers.sol#L146-L220
+        const proofAndSignature = this.params.signature!;
+
+        const signatureLength = actualSignatureLength % 2 === 0 ? 130 : 128;
+        const signature = proofAndSignature.slice(0, signatureLength + 2);
+
+        const key = bn(
+          "0x" + proofAndSignature.slice(2 + signatureLength, 2 + signatureLength + 6)
+        ).toNumber();
+
+        const height = Math.floor((proofAndSignature.length - 2 - signatureLength) / 64);
+
+        const proofElements: string[] = [];
+        for (let i = 0; i < height; i++) {
+          const start = 2 + signatureLength + 6 + i * 64;
+          proofElements.push("0x" + proofAndSignature.slice(start, start + 64).padEnd(64, "0"));
+        }
+
+        let root = this.hash();
+        for (let i = 0; i < proofElements.length; i++) {
+          if ((key >> i) % 2 === 0) {
+            root = solidityKeccak256(["bytes"], [root + proofElements[i].slice(2)]);
+          } else {
+            root = solidityKeccak256(["bytes"], [proofElements[i] + root.slice(2)]);
+          }
+        }
+
+        const types = { ...ORDER_EIP712_TYPES };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (types as any).BulkOrder = [
+          { name: "tree", type: `OrderComponents${`[2]`.repeat(height)}` },
+        ];
+        const encoder = _TypedDataEncoder.from(types);
+
+        const bulkOrderTypeHash = solidityKeccak256(["string"], [encoder.encodeType("BulkOrder")]);
+        const bulkOrderHash = solidityKeccak256(["bytes"], [bulkOrderTypeHash + root.slice(2)]);
+
+        const value = solidityKeccak256(
+          ["bytes"],
+          [
+            "0x1901" +
+              _TypedDataEncoder.hashDomain(EIP712_DOMAIN(this.chainId)).slice(2) +
+              bulkOrderHash.slice(2),
+          ]
+        );
+
+        const signer = recoverAddress(value, signature);
+        if (lc(this.params.offerer) !== lc(signer)) {
+          throw new Error("Invalid signature");
+        }
+      } else {
+        const signer = verifyTypedData(
+          EIP712_DOMAIN(this.chainId),
+          ORDER_EIP712_TYPES,
+          this.params,
+          signature
+        );
+
+        if (lc(this.params.offerer) !== lc(signer)) {
+          throw new Error("Invalid signature");
+        }
+      }
+    } catch {
+      if (!provider) {
+        throw new Error("Invalid signature");
+      }
+
+      const eip712Hash = _TypedDataEncoder.hash(
+        EIP712_DOMAIN(this.chainId),
+        ORDER_EIP712_TYPES,
+        this.params
+      );
+
+      const iface = new Interface([
+        "function isValidSignature(bytes32 digest, bytes signature) view returns (bytes4)",
+      ]);
+
+      const result = await new Contract(this.params.offerer, iface, provider).isValidSignature(
+        eip712Hash,
+        signature
+      );
+      if (result !== iface.getSighash("isValidSignature")) {
+        throw new Error("Invalid signature");
+      }
+    }
+  }
+
+  public checkValidity() {
+    const info = this.getInfo();
+    if (!info) {
+      throw new Error("Could not extract order info");
+    }
+
+    if (!bn(info.price).div(info.amount).mul(info.amount).eq(info.price)) {
+      throw new Error("Price not evenly divisible to the amount");
+    }
+
+    if (!this.getBuilder().isValid(this, Order)) {
+      throw new Error("Invalid order");
+    }
+  }
+
+  public getInfo(): BaseOrderInfo | undefined {
+    return this.getBuilder().getInfo(this);
+  }
+
+  public getKind(): SeaportOrderKind {
+    return SeaportOrderKind.ALIENSWAP;
+  }
+
+  public getMatchingPrice(timestampOverride?: number): BigNumberish {
+    const info = this.getInfo();
+    if (!info) {
+      throw new Error("Could not get order info");
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (!(info as any).isDynamic) {
+      if (info.side === "buy") {
+        return bn(info.price);
+      } else {
+        return bn(info.price).add(this.getFeeAmount());
+      }
+    } else {
+      if (info.side === "buy") {
+        // Reverse dutch-auctions are not supported
+        return bn(info.price);
+      } else {
+        let price = bn(0);
+        for (const c of this.params.consideration) {
+          price = price.add(
+            // startAmount - (currentTime - startTime) / (endTime - startTime) * (startAmount - endAmount)
+            bn(c.startAmount).sub(
+              bn(timestampOverride ?? getCurrentTimestamp(-60))
+                .sub(this.params.startTime)
+                .mul(bn(c.startAmount).sub(c.endAmount))
+                .div(bn(this.params.endTime).sub(this.params.startTime))
+            )
+          );
+          // Ensure we don't return any negative prices
+          if (price.lt(c.endAmount)) {
+            price = bn(c.endAmount);
+          }
+        }
+        return price;
+      }
+    }
+  }
+
+  public getFeeAmount(): BigNumber {
+    const { fees } = this.getBuilder()!.getInfo(this)!;
+
+    let feeAmount = bn(0);
+    for (const { amount } of fees) {
+      feeAmount = feeAmount.add(amount);
+    }
+    return feeAmount;
+  }
+
+  public buildMatching(data?: object) {
+    return this.getBuilder().buildMatching(this, data);
+  }
+
+  public async checkFillability(provider: Provider) {
+    const exchange = new Exchange(this.chainId);
+
+    const status = await exchange.contract.connect(provider).getOrderStatus(this.hash());
+    if (status.isCancelled) {
+      throw new Error("not-fillable");
+    }
+    if (status.isValidated && bn(status.totalFilled).gte(status.totalSize)) {
+      throw new Error("not-fillable");
+    }
+
+    const makerConduit = exchange.deriveConduit(this.params.conduitKey);
+
+    const info = this.getInfo()! as BaseOrderInfo;
+    if (info.side === "buy") {
+      // Check that maker has enough balance to cover the payment
+      // and the approval to the corresponding conduit is set
+      const erc20 = new Common.Helpers.Erc20(provider, info.paymentToken);
+      const balance = await erc20.getBalance(this.params.offerer);
+      if (bn(balance).lt(info.price)) {
+        throw new Error("no-balance");
+      }
+
+      // Check allowance
+      const allowance = await erc20.getAllowance(this.params.offerer, makerConduit);
+      if (bn(allowance).lt(info.price)) {
+        throw new Error("no-approval");
+      }
+    } else {
+      if (info.tokenKind === "erc721") {
+        const erc721 = new Common.Helpers.Erc721(provider, info.contract);
+
+        // Check ownership
+        const owner = await erc721.getOwner(info.tokenId!);
+        if (lc(owner) !== lc(this.params.offerer)) {
+          throw new Error("no-balance");
+        }
+
+        // Check approval
+        const isApproved = await erc721.isApproved(this.params.offerer, makerConduit);
+        if (!isApproved) {
+          throw new Error("no-approval");
+        }
+      } else {
+        const erc1155 = new Common.Helpers.Erc1155(provider, info.contract);
+
+        // Check balance
+        const balance = await erc1155.getBalance(this.params.offerer, info.tokenId!);
+        if (bn(balance).lt(info.amount)) {
+          throw new Error("no-balance");
+        }
+
+        // Check approval
+        const isApproved = await erc1155.isApproved(this.params.offerer, makerConduit);
+        if (!isApproved) {
+          throw new Error("no-approval");
+        }
+      }
+    }
+  }
+
+  private getBuilder(): BaseBuilder {
+    switch (this.params.kind) {
+      case "contract-wide": {
+        return new Builders.ContractWide(this.chainId);
+      }
+
+      case "single-token": {
+        return new Builders.SingleToken(this.chainId);
+      }
+
+      case "token-list": {
+        return new Builders.TokenList(this.chainId);
+      }
+
+      default: {
+        throw new Error("Unknown order kind");
+      }
+    }
+  }
+
+  private detectKind(): Types.OrderKind {
+    // contract-wide
+    {
+      const builder = new Builders.ContractWide(this.chainId);
+      if (builder.isValid(this, Order)) {
+        return "contract-wide";
+      }
+    }
+
+    // single-token
+    {
+      const builder = new Builders.SingleToken(this.chainId);
+      if (builder.isValid(this, Order)) {
+        return "single-token";
+      }
+    }
+
+    // token-list
+    {
+      const builder = new Builders.TokenList(this.chainId);
+      if (builder.isValid(this, Order)) {
+        return "token-list";
+      }
+    }
+
+    throw new Error("Could not detect order kind (order might have unsupported params/calldata)");
+  }
+
+  private extractSignature() {
+    if (this.params.signature) {
+      let signature = this.params.signature;
+
+      // Remove the `0x` prefix and count bytes not characters
+      const actualSignatureLength = (signature.length - 2) / 2;
+
+      // https://github.com/ProjectOpenSea/seaport/blob/4f2210b59aefa119769a154a12e55d9b77ca64eb/reference/lib/ReferenceVerifiers.sol#L126-L133
+      const isBulkSignature =
+        actualSignatureLength < 837 &&
+        actualSignatureLength > 98 &&
+        (actualSignatureLength - 67) % 32 < 2;
+      if (isBulkSignature) {
+        // https://github.com/ProjectOpenSea/seaport/blob/4f2210b59aefa119769a154a12e55d9b77ca64eb/reference/lib/ReferenceVerifiers.sol#L146-L220
+        const proofAndSignature = this.params.signature!;
+
+        const signatureLength = actualSignatureLength % 2 === 0 ? 130 : 128;
+        signature = proofAndSignature.slice(0, signatureLength + 2);
+      }
+
+      return signature;
+    }
+  }
+
+  private fixSignature() {
+    let signature = this.extractSignature();
+
+    if (signature?.length === 132) {
+      // For non-compact signatures, ensure `v` is always 27 or 28 (Seaport will revert otherwise)
+      let lastByte = parseInt(signature.slice(-2), 16);
+      if (lastByte < 27) {
+        if (lastByte === 0 || lastByte === 1) {
+          lastByte += 27;
+        } else {
+          throw new Error("Invalid `v` byte");
+        }
+
+        signature = signature.slice(0, -2) + lastByte.toString(16);
+        this.params.signature = signature + this.params.signature!.slice(signature.length);
+      }
+    }
+  }
+}
+
+export const EIP712_DOMAIN = (chainId: number) => ({
+  name: "Seaport",
+  version: "1.4",
+  chainId,
+  verifyingContract: Addresses.Exchange[chainId],
+});
+
+const normalize = (order: Types.OrderComponents): Types.OrderComponents => {
+  // Perform some normalization operations on the order:
+  // - convert bignumbers to strings where needed
+  // - convert strings to numbers where needed
+  // - lowercase all strings
+
+  return {
+    kind: order.kind,
+    offerer: lc(order.offerer),
+    zone: lc(order.zone),
+    offer: order.offer.map((o) => ({
+      itemType: n(o.itemType),
+      token: lc(o.token),
+      identifierOrCriteria: s(o.identifierOrCriteria),
+      startAmount: s(o.startAmount),
+      endAmount: s(o.endAmount),
+    })),
+    consideration: order.consideration.map((c) => ({
+      itemType: n(c.itemType),
+      token: lc(c.token),
+      identifierOrCriteria: s(c.identifierOrCriteria),
+      startAmount: s(c.startAmount),
+      endAmount: s(c.endAmount),
+      recipient: lc(c.recipient),
+    })),
+    orderType: n(order.orderType),
+    startTime: n(order.startTime),
+    endTime: n(order.endTime),
+    zoneHash: lc(order.zoneHash),
+    salt: s(order.salt),
+    conduitKey: lc(order.conduitKey),
+    counter: s(order.counter),
+    signature: order.signature ? lc(order.signature) : undefined,
+  };
+};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -26,6 +26,7 @@ import * as Quixotic from "./quixotic";
 import * as Rarible from "./rarible";
 import * as SeaportV11 from "./seaport-v1.1";
 import * as SeaportV14 from "./seaport-v1.4";
+import * as Alienswap from "./alienswap";
 import * as SeaportBase from "./seaport-base";
 import * as Sudoswap from "./sudoswap";
 import * as SuperRare from "./superrare";
@@ -70,6 +71,7 @@ export {
   Rarible,
   SeaportV11,
   SeaportV14,
+  Alienswap,
   SeaportBase,
   Sudoswap,
   SuperRare,

--- a/packages/sdk/src/router/v6/abis/AlienswapModule.json
+++ b/packages/sdk/src/router/v6/abis/AlienswapModule.json
@@ -1,0 +1,1722 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "router",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidParams",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsuccessfulCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsuccessfulFill",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsuccessfulPayment",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongParams",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "CallExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "EXCHANGE",
+    "outputs": [
+      {
+        "internalType": "contract ISeaport",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "zone",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ISeaport.ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum ISeaport.OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "salt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint120",
+            "name": "numerator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ISeaport.AdvancedOrder",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum ISeaport.Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "criteriaProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct ISeaport.CriteriaResolver[]",
+        "name": "criteriaResolvers",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.OfferParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptERC1155Offer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "zone",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ISeaport.ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum ISeaport.OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "salt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint120",
+            "name": "numerator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ISeaport.AdvancedOrder",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.ERC20ListingParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptERC20Listing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "zone",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ISeaport.ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum ISeaport.OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "salt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint120",
+            "name": "numerator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ISeaport.AdvancedOrder[]",
+        "name": "orders",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.ERC20ListingParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptERC20Listings",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "zone",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ISeaport.ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum ISeaport.OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "salt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint120",
+            "name": "numerator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ISeaport.AdvancedOrder",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "orderIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum ISeaport.Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "criteriaProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct ISeaport.CriteriaResolver[]",
+        "name": "criteriaResolvers",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.OfferParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptERC721Offer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "zone",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ISeaport.ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum ISeaport.OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "salt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint120",
+            "name": "numerator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "uint120",
+            "name": "denominator",
+            "type": "uint120"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ISeaport.AdvancedOrder",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.ETHListingParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptETHListing",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "address",
+                    "name": "offerer",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "zone",
+                    "type": "address"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "enum ISeaport.ItemType",
+                        "name": "itemType",
+                        "type": "uint8"
+                      },
+                      {
+                        "internalType": "address",
+                        "name": "token",
+                        "type": "address"
+                      },
+                      {
+                        "internalType": "uint256",
+                        "name": "identifierOrCriteria",
+                        "type": "uint256"
+                      },
+                      {
+                        "internalType": "uint256",
+                        "name": "startAmount",
+                        "type": "uint256"
+                      },
+                      {
+                        "internalType": "uint256",
+                        "name": "endAmount",
+                        "type": "uint256"
+                      }
+                    ],
+                    "internalType": "struct ISeaport.OfferItem[]",
+                    "name": "offer",
+                    "type": "tuple[]"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "enum ISeaport.ItemType",
+                        "name": "itemType",
+                        "type": "uint8"
+                      },
+                      {
+                        "internalType": "address",
+                        "name": "token",
+                        "type": "address"
+                      },
+                      {
+                        "internalType": "uint256",
+                        "name": "identifierOrCriteria",
+                        "type": "uint256"
+                      },
+                      {
+                        "internalType": "uint256",
+                        "name": "startAmount",
+                        "type": "uint256"
+                      },
+                      {
+                        "internalType": "uint256",
+                        "name": "endAmount",
+                        "type": "uint256"
+                      },
+                      {
+                        "internalType": "address",
+                        "name": "recipient",
+                        "type": "address"
+                      }
+                    ],
+                    "internalType": "struct ISeaport.ConsiderationItem[]",
+                    "name": "consideration",
+                    "type": "tuple[]"
+                  },
+                  {
+                    "internalType": "enum ISeaport.OrderType",
+                    "name": "orderType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startTime",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endTime",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes32",
+                    "name": "zoneHash",
+                    "type": "bytes32"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "salt",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "bytes32",
+                    "name": "conduitKey",
+                    "type": "bytes32"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "totalOriginalConsiderationItems",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OrderParameters",
+                "name": "parameters",
+                "type": "tuple"
+              },
+              {
+                "internalType": "uint120",
+                "name": "numerator",
+                "type": "uint120"
+              },
+              {
+                "internalType": "uint120",
+                "name": "denominator",
+                "type": "uint120"
+              },
+              {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "extraData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct ISeaport.AdvancedOrder",
+            "name": "order",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SeaportV14Module.SeaportETHListingWithPrice[]",
+        "name": "orders",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "fillTo",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "refundTo",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "revertIfIncomplete",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.ETHListingParams",
+        "name": "params",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BaseExchangeModule.Fee[]",
+        "name": "fees",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "acceptETHListings",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "targets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "makeCalls",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "offerer",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "zone",
+                "type": "address"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  }
+                ],
+                "internalType": "struct ISeaport.OfferItem[]",
+                "name": "offer",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "enum ISeaport.ItemType",
+                    "name": "itemType",
+                    "type": "uint8"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "token",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "identifierOrCriteria",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "startAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "endAmount",
+                    "type": "uint256"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "recipient",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct ISeaport.ConsiderationItem[]",
+                "name": "consideration",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "enum ISeaport.OrderType",
+                "name": "orderType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "uint256",
+                "name": "startTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "endTime",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "zoneHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "salt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes32",
+                "name": "conduitKey",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "totalOriginalConsiderationItems",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.OrderParameters",
+            "name": "parameters",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ISeaport.Order[]",
+        "name": "orders",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "orderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "itemIndex",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.FulfillmentComponent[]",
+            "name": "offerComponents",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "orderIndex",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "itemIndex",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ISeaport.FulfillmentComponent[]",
+            "name": "considerationComponents",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct ISeaport.Fulfillment[]",
+        "name": "fulfillments",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "matchOrders",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/packages/sdk/src/router/v6/addresses.ts
+++ b/packages/sdk/src/router/v6/addresses.ts
@@ -57,6 +57,14 @@ export const SeaportV14Module: ChainIdToAddress = {
   [Network.Arbitrum]: "0x07c163b007b3db7ccffef77848a766047d8ffc2d",
 };
 
+export const AlienswapModule: ChainIdToAddress = {
+  [Network.Ethereum]: "0x07c163b007b3db7ccffef77848a766047d8ffc2d",
+  [Network.EthereumGoerli]: "0x07c163b007b3db7ccffef77848a766047d8ffc2d",
+  [Network.Polygon]: "0x07c163b007b3db7ccffef77848a766047d8ffc2d",
+  [Network.Optimism]: "0x07c163b007b3db7ccffef77848a766047d8ffc2d",
+  [Network.Arbitrum]: "0x07c163b007b3db7ccffef77848a766047d8ffc2d",
+};
+
 export const SudoswapModule: ChainIdToAddress = {
   [Network.Ethereum]: "0xa97727370e2592f83602bc92975c49c4fea4491f",
 };

--- a/packages/sdk/src/router/v6/router.ts
+++ b/packages/sdk/src/router/v6/router.ts
@@ -42,6 +42,7 @@ import NFTXModuleAbi from "./abis/NFTXModule.json";
 import RaribleModuleAbi from "./abis/RaribleModule.json";
 import SeaportModuleAbi from "./abis/SeaportModule.json";
 import SeaportV14ModuleAbi from "./abis/SeaportV14Module.json";
+import AlienswapModuleAbi from "./abis/AlienswapModule.json";
 import SudoswapModuleAbi from "./abis/SudoswapModule.json";
 import SwapModuleAbi from "./abis/SwapModule.json";
 import X2Y2ModuleAbi from "./abis/X2Y2Module.json";
@@ -135,6 +136,11 @@ export class Router {
       swapModule: new Contract(
         Addresses.SwapModule[chainId] ?? AddressZero,
         SwapModuleAbi,
+        provider
+      ),
+      alienswapModule: new Contract(
+        Addresses.AlienswapModule[chainId] ?? AddressZero,
+        AlienswapModuleAbi,
         provider
       ),
     };
@@ -775,7 +781,7 @@ export class Router {
       const exchange = new Sdk.SeaportV14.Exchange(this.chainId);
 
       const conduit = exchange.deriveConduit(
-        (details[0].order as Sdk.SeaportV11.Order).params.conduitKey
+        (details[0].order as Sdk.SeaportV14.Order).params.conduitKey
       );
 
       let approval: FTApproval | undefined;
@@ -815,6 +821,82 @@ export class Router {
           txs: [
             {
               approvals: approval ? [approval] : [],
+              txData: await exchange.fillOrdersTx(
+                taker,
+                orders,
+                orders.map((order, i) => order.buildMatching({ amount: details[i].amount })),
+                {
+                  ...options,
+                  ...options?.directFillingData,
+                }
+              ),
+              orderIds: details.map((d) => d.orderId),
+            },
+          ],
+          success: Object.fromEntries(details.map((d) => [d.orderId, true])),
+        };
+      }
+    }
+
+    if (
+      details.every(
+        ({ kind, fees, currency, order }) =>
+          kind === "alienswap" &&
+          buyInCurrency === currency &&
+          // All orders must have the same currency and conduit
+          currency === details[0].currency &&
+          (order as Sdk.Alienswap.Order).params.conduitKey ===
+            (details[0].order as Sdk.Alienswap.Order).params.conduitKey &&
+          !fees?.length
+      ) &&
+      !options?.globalFees?.length &&
+      !options?.forceRouter &&
+      !options?.relayer
+    ) {
+      const exchange = new Sdk.Alienswap.Exchange(this.chainId);
+
+      const conduit = exchange.deriveConduit(
+        (details[0].order as Sdk.Alienswap.Order).params.conduitKey
+      );
+
+      let approval: FTApproval | undefined;
+      if (!isETH(this.chainId, details[0].currency)) {
+        approval = {
+          currency: details[0].currency,
+          owner: taker,
+          operator: conduit,
+          txData: generateFTApprovalTxData(details[0].currency, taker, conduit),
+        };
+      }
+
+      if (details.length === 1) {
+        const order = details[0].order as Sdk.Alienswap.Order;
+        return {
+          txs: [
+            {
+              approvals: approval ? [approval] : [],
+              permits: [],
+              txData: await exchange.fillOrderTx(
+                taker,
+                order,
+                order.buildMatching({ amount: details[0].amount }),
+                {
+                  ...options,
+                  ...options?.directFillingData,
+                }
+              ),
+              orderIds: [details[0].orderId],
+            },
+          ],
+          success: { [details[0].orderId]: true },
+        };
+      } else {
+        const orders = details.map((d) => d.order as Sdk.Alienswap.Order);
+        return {
+          txs: [
+            {
+              approvals: approval ? [approval] : [],
+              permits: [],
               txData: await exchange.fillOrdersTx(
                 taker,
                 orders,
@@ -875,6 +957,7 @@ export class Router {
     // Only `seaport` and `seaport-v1.4` support non-ETH listings
     const seaportDetails: PerCurrencyListingDetails = {};
     const seaportV14Details: PerCurrencyListingDetails = {};
+    const alienswapDetails: PerCurrencyListingDetails = {};
     const sudoswapDetails: ListingDetails[] = [];
     const x2y2Details: ListingDetails[] = [];
     const zeroexV4Erc721Details: ListingDetails[] = [];
@@ -924,6 +1007,13 @@ export class Router {
             seaportV14Details[currency] = [];
           }
           detailsRef = seaportV14Details[currency];
+          break;
+
+        case "alienswap":
+          if (!alienswapDetails[currency]) {
+            alienswapDetails[currency] = [];
+          }
+          detailsRef = alienswapDetails[currency];
           break;
 
         case "sudoswap":
@@ -2861,6 +2951,49 @@ export class Router {
               throw new Error(getErrorMessage(error));
             }
           }
+
+          break;
+        }
+
+        case "alienswap": {
+          const order = detail.order as Sdk.Alienswap.Order;
+          const module = this.contracts.AlienswapModule;
+
+          const matchParams = order.buildMatching({
+            tokenId: detail.tokenId,
+            amount: detail.amount ?? 1,
+            ...(detail.extraArgs ?? {}),
+          });
+
+          const exchange = new Sdk.Alienswap.Exchange(this.chainId);
+          executions.push({
+            module: module.address,
+            data: module.interface.encodeFunctionData(
+              detail.contractKind === "erc721" ? "acceptERC721Offer" : "acceptERC1155Offer",
+              [
+                {
+                  parameters: {
+                    ...order.params,
+                    totalOriginalConsiderationItems: order.params.consideration.length,
+                  },
+                  numerator: matchParams.amount ?? 1,
+                  denominator: order.getInfo()!.amount,
+                  signature: order.params.signature,
+                  extraData: await exchange.getExtraData(order),
+                },
+                matchParams.criteriaResolvers ?? [],
+                {
+                  fillTo: taker,
+                  refundTo: taker,
+                  revertIfIncomplete: Boolean(!options?.partial),
+                },
+                detail.fees ?? [],
+              ]
+            ),
+            value: 0,
+          });
+
+          success[i] = true;
 
           break;
         }

--- a/packages/sdk/src/router/v6/types.ts
+++ b/packages/sdk/src/router/v6/types.ts
@@ -80,6 +80,10 @@ export type GenericOrder =
       order: Sdk.SeaportBase.Types.PartialOrder;
     }
   | {
+      kind: "alienswap";
+      order: Sdk.Alienswap.Order;
+    }
+  | {
       kind: "cryptopunks";
       order: Sdk.CryptoPunks.Order;
     }

--- a/packages/sdk/src/seaport-base/exchange.ts
+++ b/packages/sdk/src/seaport-base/exchange.ts
@@ -14,12 +14,11 @@ import { ConduitController } from "../seaport-base";
 
 export abstract class SeaportBaseExchange {
   public chainId: number;
-  public contract: Contract;
+  public abstract contract: Contract;
   public conduitController: ConduitController;
 
-  constructor(chainId: number, contract: Contract) {
+  constructor(chainId: number) {
     this.chainId = chainId;
-    this.contract = contract;
     this.conduitController = new ConduitController(this.chainId);
   }
 

--- a/packages/sdk/src/seaport-base/index.ts
+++ b/packages/sdk/src/seaport-base/index.ts
@@ -3,7 +3,7 @@ import { ConduitController } from "./conduit-controller";
 import { Builders } from "./builders";
 import { BaseBuildParams, BaseBuilder } from "./builders/base";
 import * as Types from "./types";
-import { IOrder } from "./order";
+import { IOrder, SeaportOrderKind } from "./order";
 import { SeaportBaseExchange } from "./exchange";
 
 export {
@@ -14,5 +14,6 @@ export {
   ConduitController,
   Types,
   IOrder,
+  SeaportOrderKind,
   SeaportBaseExchange,
 };

--- a/packages/sdk/src/seaport-base/order.ts
+++ b/packages/sdk/src/seaport-base/order.ts
@@ -5,6 +5,7 @@ import { BigNumberish } from "@ethersproject/bignumber";
 export enum SeaportOrderKind {
   SEAPORT_V11 = "seaport",
   SEAPORT_V14 = "seaport-v1.4",
+  ALIENSWAP = "alienswap",
 }
 
 export interface IOrder {
@@ -18,6 +19,9 @@ export interface IOrder {
   getMatchingPrice(timestampOverride?: number): BigNumberish;
 
   hash(): string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getSignatureData(): any;
 }
 
 export const ORDER_EIP712_TYPES = {

--- a/packages/sdk/src/seaport-v1.4/exchange.ts
+++ b/packages/sdk/src/seaport-v1.4/exchange.ts
@@ -18,16 +18,22 @@ import ExchangeAbi from "./abis/Exchange.json";
 import { SeaportBaseExchange } from "../seaport-base/exchange";
 
 export class Exchange extends SeaportBaseExchange {
+  protected exchangeAddress: string;
+  protected cancellationZoneAddress: string;
+  public contract: Contract;
+
   constructor(chainId: number) {
-    const contract = new Contract(Addresses.Exchange[chainId], ExchangeAbi);
-    super(chainId, contract);
+    super(chainId);
+    this.exchangeAddress = Addresses.Exchange[chainId];
+    this.cancellationZoneAddress = Addresses.CancellationZone[chainId];
+    this.contract = new Contract(this.exchangeAddress, ExchangeAbi);
   }
 
   // --- Derive conduit from key ---
 
   public deriveConduit(conduitKey: string) {
     return conduitKey === HashZero
-      ? Addresses.Exchange[this.chainId]
+      ? this.exchangeAddress
       : this.conduitController.deriveConduit(conduitKey);
   }
 
@@ -127,7 +133,7 @@ export class Exchange extends SeaportBaseExchange {
   // --- Get extra data ---
 
   public requiresExtraData(order: IOrder): boolean {
-    if (order.params.zone === Addresses.CancellationZone[this.chainId]) {
+    if (order.params.zone === this.cancellationZoneAddress) {
       return true;
     }
     return false;
@@ -136,7 +142,7 @@ export class Exchange extends SeaportBaseExchange {
   // matchParams should always pass for seaport-v1.4
   public async getExtraData(order: IOrder, matchParams?: Types.MatchParams): Promise<string> {
     switch (order.params.zone) {
-      case Addresses.CancellationZone[this.chainId]: {
+      case this.cancellationZoneAddress: {
         return axios
           .post(
             `https://seaport-oracle-${


### PR DESCRIPTION
Goal: integrate my own seaport-v1.4 fork contract into reservoir, and create a new order_type named `alienswap`

What I have changed:
1. Changed `get-execute-list/v5.ts`, `get-execute-bid/v5.ts`, `get-execute-buy/v7.ts`, `get-execute-sell/v7.ts`, `get-execute-cancel/v2.ts`, adding `alienswap` orderKind
2. Added a new folder named `alienswap` in `orderbook/orders`, mostly copied from `seaport-v1.4`
3. Added a new folder named `alienswap` in `sdk/src`
4. Modified `sync/events/data`, support syncing events from the fork contract
5. Modified `router/v6` mainly to support sending full fill transaction to contract

What I have tested:
1. list, buy, cancel work
2. fill_events_2 can sync events from chain

What to be done:
1. Deploy AlienswapModule.sol
2. Support bid and offer and do some tests
3. Support partial order
4. Support offchain cancellation
