### PR TITLE
Alienswap offchain cancellation

### DIFF
--- a/packages/indexer/src/api/endpoints/execute/post-cancel-signature/v1.ts
+++ b/packages/indexer/src/api/endpoints/execute/post-cancel-signature/v1.ts
@@ -27,6 +27,10 @@ export const postCancelSignatureV1Options: RouteOptions = {
         .min(1)
         .required()
         .description("Ids of the orders to cancel"),
+      orderKind: Joi.string()
+        .valid("seaport-v1.4", "alienswap")
+        .default("seaport-v1.4")
+        .description("Exchange protocol used to bulk cancel order. Example: `seaport-v1.4`"),
     }),
   },
   response: {
@@ -46,6 +50,7 @@ export const postCancelSignatureV1Options: RouteOptions = {
     try {
       const signature = query.signature;
       const orderIds = payload.orderIds;
+      const orderKind = payload.orderKind;
 
       const ordersResult = await idb.manyOrNone(
         `
@@ -63,9 +68,9 @@ export const postCancelSignatureV1Options: RouteOptions = {
       }
 
       await axios.post(
-        `https://seaport-oracle-${
-          config.chainId === 1 ? "mainnet" : "goerli"
-        }.up.railway.app/api/cancellations`,
+        `https://seaport-oracle-${config.chainId === 1 ? "mainnet" : "goerli"}.up.railway.app/api/${
+          orderKind === "seaport-v1.4" ? "" : "alienswap/"
+        }cancellations`,
         {
           signature,
           orders: ordersResult.map((o) => o.raw_data),

--- a/packages/indexer/src/jobs/orderbook/post-order-external/api/opensea/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/api/opensea/index.ts
@@ -50,16 +50,16 @@ export const postOrder = async (order: Sdk.SeaportV14.Order, apiKey: string) => 
       }
     )
     .catch((error) => {
+      if (error.response) {
+        handleErrorResponse(error.response);
+      }
+
       logger.error(
         "opensea-orderbook-api",
         `Post OpenSea order error. apiKey=${apiKey}, error=${error}, responseStatus=${
           error.response?.status
         }, responseData=${JSON.stringify(error.response?.data)}`
       );
-
-      if (error.response) {
-        handleErrorResponse(error.response);
-      }
 
       throw new Error(`Failed to post order to OpenSea`);
     });
@@ -103,16 +103,16 @@ export const buildCollectionOffer = async (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then((response) => response.data as any)
       .catch((error) => {
+        if (error.response) {
+          handleErrorResponse(error.response);
+        }
+
         logger.error(
           "opensea-orderbook-api",
           `Build OpenSea collection offer error. offerer=${offerer}, quantity=${quantity}, collectionSlug=${collectionSlug}, apiKey=${apiKey}, error=${error}, responseStatus=${
             error.response?.status
           }, responseData=${JSON.stringify(error.response?.data)}`
         );
-
-        if (error.response) {
-          handleErrorResponse(error.response);
-        }
 
         throw new Error(`Failed to build OpenSea collection offer`);
       })
@@ -162,16 +162,16 @@ export const buildTraitOffer = async (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then((response) => response.data as any)
       .catch((error) => {
+        if (error.response) {
+          handleErrorResponse(error.response);
+        }
+
         logger.error(
           "opensea_orderbook_api",
           `Build OpenSea trait offer error. offerer=${offerer}, quantity=${quantity}, collectionSlug=${collectionSlug}, traitType=${traitType}, traitValue=${traitValue}, apiKey=${apiKey}, error=${error}, responseStatus=${
             error.response?.status
           }, responseData=${JSON.stringify(error.response?.data)}`
         );
-
-        if (error.response) {
-          handleErrorResponse(error.response);
-        }
 
         throw new Error(`Failed to build OpenSea trait offer`);
       })
@@ -220,16 +220,16 @@ export const postCollectionOffer = async (
             },
     })
     .catch((error) => {
+      if (error.response) {
+        handleErrorResponse(error.response);
+      }
+
       logger.error(
         "opensea-orderbook-api",
         `Post OpenSea collection offer error. collectionSlug=${collectionSlug}, apiKey=${apiKey}, data=${data}, error=${error}, responseStatus=${
           error.response?.status
         }, responseData=${JSON.stringify(error.response?.data)}`
       );
-
-      if (error.response) {
-        handleErrorResponse(error.response);
-      }
 
       throw new Error(`Failed to post offer to OpenSea`);
     });
@@ -281,6 +281,10 @@ export const postTraitOffer = async (
             },
     })
     .catch((error) => {
+      if (error.response) {
+        handleErrorResponse(error.response);
+      }
+
       logger.error(
         "opensea-orderbook-api",
         `Post OpenSea trait offer error. order=${JSON.stringify(
@@ -289,10 +293,6 @@ export const postTraitOffer = async (
           error.response?.status
         }, responseData=${JSON.stringify(error.response?.data)}`
       );
-
-      if (error.response) {
-        handleErrorResponse(error.response);
-      }
 
       throw new Error(`Failed to post offer to OpenSea`);
     });

--- a/packages/indexer/src/jobs/orderbook/post-order-external/api/opensea/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/api/opensea/index.ts
@@ -183,6 +183,11 @@ export const postCollectionOffer = async (
   collectionSlug: string,
   apiKey: string
 ) => {
+  // Skip posting orders that already expired
+  if (order.params.endTime <= now()) {
+    throw new InvalidRequestError("Order is expired");
+  }
+
   const url = `${getOpenseaBaseUrl()}/v2/offers`;
 
   const data = JSON.stringify({
@@ -236,6 +241,11 @@ export const postTraitOffer = async (
   attribute: { key: string; value: string },
   apiKey: string
 ) => {
+  // Skip posting orders that already expired
+  if (order.params.endTime <= now()) {
+    throw new InvalidRequestError("Order is expired");
+  }
+
   const url = `https://${getOpenseaSubDomain()}.opensea.io/v2/offers`;
   const data = JSON.stringify({
     criteria: {

--- a/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
@@ -123,7 +123,7 @@ if (config.doBackgroundWork) {
 
             await addToQueue(job.data, delay, true);
 
-            logger.info(
+            logger.warn(
               QUEUE_NAME,
               `Post Order Throttled. orderbook=${orderbook}, orderbookApiKey=${orderbookApiKey}, crossPostingOrderId=${crossPostingOrderId}, orderId=${orderId}, orderData=${JSON.stringify(
                 orderData

--- a/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/index.ts
@@ -213,7 +213,7 @@ if (config.doBackgroundWork) {
     },
     {
       connection: redis.duplicate(),
-      concurrency: 10,
+      concurrency: 3,
     }
   );
 

--- a/packages/indexer/src/jobs/websocket-events/ask-websocket-events-trigger-queue.ts
+++ b/packages/indexer/src/jobs/websocket-events/ask-websocket-events-trigger-queue.ts
@@ -37,9 +37,9 @@ if (config.doBackgroundWork && config.doWebsocketServerWork) {
   const worker = new Worker(
     QUEUE_NAME,
     async (job: Job) => {
-      try {
-        const { data } = job.data as EventInfo;
+      const { data } = job.data as EventInfo;
 
+      try {
         const criteriaBuildQuery = Orders.buildCriteriaQuery("orders", "token_set_id", false);
 
         const rawResult = await idb.oneOrNone(
@@ -170,7 +170,9 @@ if (config.doBackgroundWork && config.doWebsocketServerWork) {
       } catch (error) {
         logger.error(
           QUEUE_NAME,
-          `Error processing websocket event. error=${JSON.stringify(error)}`
+          `Error processing websocket event. data=${JSON.stringify(data)}, error=${JSON.stringify(
+            error
+          )}`
         );
 
         throw error;

--- a/packages/indexer/src/jobs/websocket-events/bid-websocket-events-trigger-queue.ts
+++ b/packages/indexer/src/jobs/websocket-events/bid-websocket-events-trigger-queue.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "crypto";
 import _ from "lodash";
 import * as Sdk from "@reservoir0x/sdk";
 
-import { redb } from "@/common/db";
+import { idb } from "@/common/db";
 import { getJoiPriceObject } from "@/common/joi";
 import { fromBuffer, getNetAmount } from "@/common/utils";
 import { Sources } from "@/models/sources";
@@ -44,7 +44,7 @@ if (config.doBackgroundWork && config.doWebsocketServerWork) {
       try {
         const criteriaBuildQuery = Orders.buildCriteriaQuery("orders", "token_set_id", false);
 
-        const rawResult = await redb.oneOrNone(
+        const rawResult = await idb.oneOrNone(
           `
             SELECT orders.id,
             orders.kind,

--- a/packages/indexer/src/jobs/websocket-events/bid-websocket-events-trigger-queue.ts
+++ b/packages/indexer/src/jobs/websocket-events/bid-websocket-events-trigger-queue.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "crypto";
 import _ from "lodash";
 import * as Sdk from "@reservoir0x/sdk";
 
-import { idb } from "@/common/db";
+import { redb } from "@/common/db";
 import { getJoiPriceObject } from "@/common/joi";
 import { fromBuffer, getNetAmount } from "@/common/utils";
 import { Sources } from "@/models/sources";
@@ -41,10 +41,11 @@ if (config.doBackgroundWork && config.doWebsocketServerWork) {
     async (job: Job) => {
       const { data } = job.data as EventInfo;
 
-      const criteriaBuildQuery = Orders.buildCriteriaQuery("orders", "token_set_id", false);
+      try {
+        const criteriaBuildQuery = Orders.buildCriteriaQuery("orders", "token_set_id", false);
 
-      const rawResult = await idb.oneOrNone(
-        `
+        const rawResult = await redb.oneOrNone(
+          `
             SELECT orders.id,
             orders.kind,
             orders.side,
@@ -87,88 +88,97 @@ if (config.doBackgroundWork && config.doWebsocketServerWork) {
           FROM orders
           WHERE orders.id = $/orderId/
         `,
-        { orderId: data.orderId }
-      );
+          { orderId: data.orderId }
+        );
 
-      const sources = await Sources.getInstance();
+        const sources = await Sources.getInstance();
 
-      const feeBreakdown = rawResult.fee_breakdown;
-      const feeBps = rawResult.fee_bps;
+        const feeBreakdown = rawResult.fee_breakdown;
+        const feeBps = rawResult.fee_bps;
 
-      let source: SourcesEntity | undefined;
-      if (rawResult.token_set_id?.startsWith("token")) {
-        const [, contract, tokenId] = rawResult.token_set_id.split(":");
-        source = sources.get(Number(rawResult.source_id_int), contract, tokenId);
-      } else {
-        source = sources.get(Number(rawResult.source_id_int));
+        let source: SourcesEntity | undefined;
+        if (rawResult.token_set_id?.startsWith("token")) {
+          const [, contract, tokenId] = rawResult.token_set_id.split(":");
+          source = sources.get(Number(rawResult.source_id_int), contract, tokenId);
+        } else {
+          source = sources.get(Number(rawResult.source_id_int));
+        }
+
+        const result = {
+          id: rawResult.id,
+          kind: rawResult.kind,
+          side: rawResult.side,
+          status: rawResult.status,
+          tokenSetId: rawResult.token_set_id,
+          tokenSetSchemaHash: fromBuffer(rawResult.token_set_schema_hash),
+          nonce: Number(rawResult.nonce),
+          contract: fromBuffer(rawResult.contract),
+          maker: fromBuffer(rawResult.maker),
+          taker: fromBuffer(rawResult.taker),
+          price: await getJoiPriceObject(
+            {
+              gross: {
+                amount: rawResult.currency_price ?? rawResult.price,
+                nativeAmount: rawResult.price,
+              },
+              net: {
+                amount: getNetAmount(
+                  rawResult.currency_price ?? rawResult.price,
+                  _.min([rawResult.fee_bps, 10000])
+                ),
+                nativeAmount: getNetAmount(rawResult.price, _.min([rawResult.fee_bps, 10000])),
+              },
+            },
+            rawResult.currency
+              ? fromBuffer(rawResult.currency)
+              : rawResult.side === "sell"
+              ? Sdk.Common.Addresses.Eth[config.chainId]
+              : Sdk.Common.Addresses.Weth[config.chainId],
+            undefined
+          ),
+          validFrom: Number(rawResult.valid_from),
+          validUntil: Number(rawResult.valid_until),
+          quantityFilled: Number(rawResult.quantity_filled),
+          quantityRemaining: Number(rawResult.quantity_remaining),
+
+          criteria: rawResult.criteria,
+          source: {
+            id: source?.address,
+            domain: source?.domain,
+            name: source?.getTitle(),
+            icon: source?.getIcon(),
+            url: source?.metadata.url,
+          },
+          feeBps: Number(feeBps.toString()),
+          feeBreakdown: feeBreakdown,
+          expiration: Number(rawResult.expiration),
+          isReservoir: rawResult.is_reservoir,
+          isDynamic: Boolean(rawResult.dynamic || rawResult.kind === "sudoswap"),
+          createdAt: new Date(rawResult.created_at).toISOString(),
+          rawData: rawResult.raw_data,
+        };
+
+        const eventType = data.kind === "new-order" ? "bid.created" : "bid.updated";
+
+        await redisWebsocketPublisher.publish(
+          "events",
+          JSON.stringify({
+            event: eventType,
+            tags: {
+              contract: fromBuffer(rawResult.contract),
+            },
+            data: result,
+          })
+        );
+      } catch (error) {
+        logger.error(
+          QUEUE_NAME,
+          `Error processing websocket event. data=${JSON.stringify(data)}, error=${JSON.stringify(
+            error
+          )}`
+        );
+        throw error;
       }
-
-      const result = {
-        id: rawResult.id,
-        kind: rawResult.kind,
-        side: rawResult.side,
-        status: rawResult.status,
-        tokenSetId: rawResult.token_set_id,
-        tokenSetSchemaHash: fromBuffer(rawResult.token_set_schema_hash),
-        nonce: Number(rawResult.nonce),
-        contract: fromBuffer(rawResult.contract),
-        maker: fromBuffer(rawResult.maker),
-        taker: fromBuffer(rawResult.taker),
-        price: await getJoiPriceObject(
-          {
-            gross: {
-              amount: rawResult.currency_price ?? rawResult.price,
-              nativeAmount: rawResult.price,
-            },
-            net: {
-              amount: getNetAmount(
-                rawResult.currency_price ?? rawResult.price,
-                _.min([rawResult.fee_bps, 10000])
-              ),
-              nativeAmount: getNetAmount(rawResult.price, _.min([rawResult.fee_bps, 10000])),
-            },
-          },
-          rawResult.currency
-            ? fromBuffer(rawResult.currency)
-            : rawResult.side === "sell"
-            ? Sdk.Common.Addresses.Eth[config.chainId]
-            : Sdk.Common.Addresses.Weth[config.chainId],
-          undefined
-        ),
-        validFrom: Number(rawResult.valid_from),
-        validUntil: Number(rawResult.valid_until),
-        quantityFilled: Number(rawResult.quantity_filled),
-        quantityRemaining: Number(rawResult.quantity_remaining),
-
-        criteria: rawResult.criteria,
-        source: {
-          id: source?.address,
-          domain: source?.domain,
-          name: source?.getTitle(),
-          icon: source?.getIcon(),
-          url: source?.metadata.url,
-        },
-        feeBps: Number(feeBps.toString()),
-        feeBreakdown: feeBreakdown,
-        expiration: Number(rawResult.expiration),
-        isReservoir: rawResult.is_reservoir,
-        isDynamic: Boolean(rawResult.dynamic || rawResult.kind === "sudoswap"),
-        createdAt: new Date(rawResult.created_at).toISOString(),
-        rawData: rawResult.raw_data,
-      };
-
-      const eventType = data.kind === "new-order" ? "bid.created" : "bid.updated";
-
-      await redisWebsocketPublisher.publish(
-        "events",
-        JSON.stringify({
-          event: eventType,
-          tags: {
-            contract: fromBuffer(rawResult.contract),
-          },
-          data: result,
-        })
-      );
     },
     { connection: redis.duplicate(), concurrency: 20 }
   );

--- a/packages/indexer/src/orderbook/orders/alienswap/index.ts
+++ b/packages/indexer/src/orderbook/orders/alienswap/index.ts
@@ -465,7 +465,7 @@ export const save = async (orderInfos: OrderInfo[]): Promise<SaveResult[]> => {
           await axios.post(
             `https://seaport-oracle-${
               config.chainId === 1 ? "mainnet" : "goerli"
-            }.up.railway.app/api/replacements`,
+            }.up.railway.app/api/alienswap/replacements`,
             {
               newOrders: [order.params],
               replacedOrders: [replacedOrderResult.raw_data],

--- a/packages/sdk/src/alienswap/exchange.ts
+++ b/packages/sdk/src/alienswap/exchange.ts
@@ -14,6 +14,9 @@ export class Exchange extends SeaportV14Exchange {
     this.exchangeAddress = Addresses.Exchange[chainId];
     this.cancellationZoneAddress = CancellationZone[chainId];
     this.contract = new Contract(this.exchangeAddress, ExchangeAbi);
+    this.oracleSignatureUrl = `https://seaport-oracle-${
+      this.chainId === 1 ? "mainnet" : "goerli"
+    }.up.railway.app/api/alienswap/signatures`;
   }
 
   public eip712Domain(): {


### PR DESCRIPTION
seaport-oracle sign/verify use eip712 that means exchange contract address will be used, so when calling `seaport-oracle`, we must distinguish which orderKind it is, `alienswap` or `seaport-v1.4`

Please also review `seaport-oracle` at: https://github.com/reservoirprotocol/seaport-oracle/pull/2

