### PR TITLE
feat: support match tokenName

### DIFF
--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v5.ts
@@ -675,7 +675,8 @@ export const getTokensV5Options: RouteOptions = {
       }
 
       if (query.tokenName) {
-        conditions.push(`t.name = $/tokenName/`);
+        query.tokenName = "%" + query.tokenName + "%";
+        conditions.push(`t.name ILIKE $/tokenName/`);
       }
 
       if (query.tokenSetId) {

--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
@@ -680,7 +680,8 @@ export const getTokensV6Options: RouteOptions = {
       }
 
       if (query.tokenName) {
-        conditions.push(`t.name = $/tokenName/`);
+        query.tokenName = "%" + query.tokenName + "%";
+        conditions.push(`t.name ILIKE $/tokenName/`);
       }
 
       if (query.tokenSetId) {


### PR DESCRIPTION
Want to support matching feature like opensea:
![telegram-cloud-photo-size-5-6194754111707132936-y](https://user-images.githubusercontent.com/4054836/233238760-ce5dd1a9-26a6-4d4f-9db1-52a9b03d9db3.jpg)

Did a simple test to test sql injection:
```js
let tokenName = "bc\" drop";
tokenName = "%" + tokenName + "%";
const sql = `select * from orders where name ilike $/tokenName/`;
(async () => {
  const res = await redb.manyOrNone(sql, { tokenName });
  console.log(res);
})();
```
And got
<img width="581" alt="image" src="https://user-images.githubusercontent.com/4054836/233239926-8f958c41-0751-4ea7-9268-01c45c24685f.png">


Should be safe, please review
