### PR TITLE
feat: optimize contract runs

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -45,6 +45,23 @@ const getNetworkConfig = (chainId?: number) => {
 };
 const networkConfig = getNetworkConfig();
 
+const optimizerSettingsNoSpecializer = {
+  enabled: true,
+  runs: 1000000000,
+  details: {
+    peephole: true,
+    inliner: true,
+    jumpdestRemover: true,
+    orderLiterals: true,
+    deduplicate: true,
+    cse: true,
+    constantOptimizer: true,
+    yulDetails: {
+      stackAllocation: true,
+    },
+  },
+};
+
 const config: HardhatUserConfig = {
   solidity: {
     compilers: [
@@ -52,10 +69,7 @@ const config: HardhatUserConfig = {
         version: "0.8.17",
         settings: {
           viaIR: true,
-          optimizer: {
-            enabled: true,
-            runs: 200,
-          },
+          optimizer: optimizerSettingsNoSpecializer,
         },
       },
     ],


### PR DESCRIPTION
I hear that increase runs can decrease gas. The optimizer config was copied from opensea 
https://github.com/ProjectOpenSea/seaport/blob/main/hardhat.config.ts#L46-L58

I deployed 2 contracts on goerli with 200 and 100000000 runs:
AlienswapModule (200 runs): https://goerli.etherscan.io/address/0xb56fa88072f5e299331cbb810d25075f6caa889c#code
AlienswapModule (100000000 runs): https://goerli.etherscan.io/address/0x4f6557215c1af21b8143f290f011cf9639ae210e#code

## Bid/offer test

100000000 runs:
https://goerli.etherscan.io/tx/0x21cc3bbe2800c55ba3d74da18ae259561bd4150cc74f9afedde605f44c47f22f
gas used:  251,865
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/4054836/233566958-5fc4ffb7-3517-4895-8663-1b1746b08562.png">


200 runs:
https://goerli.etherscan.io/tx/0x29e2bcef1d48cfda4fa11eb09272f8e9fe77558f69c57e0101a889cf7660f257
gas used: 230,157
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/4054836/233567202-20d5494b-a55a-46d1-ae18-21f15dc5987f.png">

## Bulk list/buy test
100000000 runs:
https://goerli.etherscan.io/tx/0x2fae0e08e449ceb9719633deac765b6493704afc259b9073a1e5dfd106500bd4
<img width="925" alt="image" src="https://user-images.githubusercontent.com/4054836/233585323-ba2304ef-8cd5-4861-9449-4a1714e70529.png">

200 runs:
https://goerli.etherscan.io/tx/0xffe93014315d9974632dd21cd6149ec7faa799d94d0f73818e7a4efa5a7e742e
<img width="925" alt="image" src="https://user-images.githubusercontent.com/4054836/233585553-2f2f1a22-d015-4107-ac49-0f246f86428b.png">

## conclusion
Try to increase runs may not decrease gas fee for the router transaction
