### PR TITLE
add contractsSetId filtering to /orders/asks/v4

### DIFF
--- a/packages/indexer/src/api/endpoints/orders/get-orders-asks/v4.ts
+++ b/packages/indexer/src/api/endpoints/orders/get-orders-asks/v4.ts
@@ -19,6 +19,7 @@ import { CollectionSets } from "@/models/collection-sets";
 import { Sources } from "@/models/sources";
 import { Orders } from "@/utils/orders";
 import { TokenSets } from "@/models/token-sets";
+import { ContractSets } from "@/models/contract-sets";
 
 const version = "v4";
 
@@ -60,6 +61,7 @@ export const getOrdersAsksV4Options: RouteOptions = {
       collectionsSetId: Joi.string()
         .lowercase()
         .description("Filter to a particular collection set."),
+      contractsSetId: Joi.string().lowercase().description("Filter to a particular contracts set."),
       contracts: Joi.alternatives()
         .try(
           Joi.array().max(80).items(Joi.string().lowercase().pattern(regex.address)),
@@ -340,6 +342,13 @@ export const getOrdersAsksV4Options: RouteOptions = {
         if (contractFilter) {
           query.contractFilter = toBuffer(contractFilter);
           conditions.push(`orders.contract = $/contractFilter/`);
+        }
+      }
+
+      if (query.contractsSetId) {
+        query.contracts = await ContractSets.getContracts(query.contractsSetId);
+        if (_.isEmpty(query.contracts)) {
+          throw Boom.badRequest(`No contracts for contracts set ${query.contractsSetId}`);
         }
       }
 


### PR DESCRIPTION
- Add `contractsSetId` filtering to the `/orders/asks/v4` endpoint

Influenced by the `contractsSetId` filtering seen here: https://github.com/reservoirprotocol/indexer/blob/main/packages/indexer/src/api/endpoints/activities/get-user-activity/v6.ts#L177-L182