### PR TITLE
Improve error message clarity for OpenSea cross posting failures

### DIFF
--- a/packages/indexer/src/jobs/orderbook/post-order-external/api/opensea/index.ts
+++ b/packages/indexer/src/jobs/orderbook/post-order-external/api/opensea/index.ts
@@ -349,7 +349,7 @@ const handleErrorResponse = (response: any) => {
     }
     case 400: {
       const error = response.data.errors?.toString();
-      const message = `Request was rejected by OpenSea. error=${error}`;
+      const message = `Request was rejected by OpenSea. error=${JSON.stringify(error)}`;
 
       const invalidFeeErrors = [
         "You have provided a fee",


### PR DESCRIPTION
This PR addresses an issue in the error handling when dealing with OpenSea API failures. As it stands, the error messaging system is not providing sufficient information for efficient debugging due to the nature of the response.data.errors object.

Current error messages look as follows:
```
Request was rejected by OpenSea. error=[object Object]
```

This output is less than ideal, as it does not provide specific details about what went wrong with the request.

To enhance the clarity and utility of our error messaging, this PR introduces a change to stringify the response.data.errors object. By doing so, we can gain a clearer understanding of the underlying issue when a request fails. This improvement will aid in quicker identification and resolution of problems, thereby improving overall system robustness and reliability.