### PR TITLE
feat: update descriptions on /post-cancel-signature/v1.ts

### DIFF
--- a/packages/indexer/src/api/endpoints/execute/post-cancel-signature/v1.ts
+++ b/packages/indexer/src/api/endpoints/execute/post-cancel-signature/v1.ts
@@ -15,6 +15,7 @@ const version = "v1";
 
 export const postCancelSignatureV1Options: RouteOptions = {
   description: "Off-chain cancel orders",
+  notes: "If your order was created using the Seaport Oracle to allow off chain & gasless cancellations, you can just use the Kit's cancel modals, SDK's `cancelOrder`, or `/execute/cancel/`. Those tools will automatically access this endpoint for an oracle cancellation without you directly calling this endpoint.",
   tags: ["api", "Misc"],
   plugins: {
     "hapi-swagger": {


### PR DESCRIPTION
Clarify that the normal cancel methods with access this without needing a direct call.