### PR TITLE
add top selling collections endpoint

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/get-top-selling-collections/v1.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-top-selling-collections/v1.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Request, RouteOptions } from "@hapi/hapi";
+import _ from "lodash";
+import Joi from "joi";
+
+import { logger } from "@/common/logger";
+import { regex } from "@/common/utils";
+
+import {
+  getTopSellingCollections,
+  TopSellingFillOptions,
+} from "@/elasticsearch/indexes/activities";
+
+const version = "v5";
+
+export const getTopSellingCollectionsOptions: RouteOptions = {
+  cache: {
+    privacy: "public",
+    expiresIn: 10000,
+  },
+  description: "Collections",
+  notes: "Get top selling collections for a particular time range.",
+  tags: ["api", "Collections"],
+  plugins: {
+    "hapi-swagger": {
+      order: 3,
+    },
+  },
+  validate: {
+    query: Joi.object({
+      startTime: Joi.number()
+        .greater(Math.floor((Date.now() - 14 * 24 * 60 * 60 * 1000) / 1000))
+        .default(Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 1000))
+        .description(
+          "Start time in unix timestamp. Must be less than 2 weeks ago. defaults to 24 hours"
+        ),
+      endTime: Joi.number().description("End time in unix timestamp. defaults to now"),
+      fillType: Joi.string()
+        .lowercase()
+        .valid(..._.values(TopSellingFillOptions))
+        .default(TopSellingFillOptions.any)
+        .description("Fill types to aggregate from (sale, mint, any)"),
+
+      limit: Joi.number()
+        .integer()
+        .min(1)
+        .max(50)
+        .default(25)
+        .description("Amount of items returned in response. Default is 25 and max is 50"),
+    }),
+  },
+  response: {
+    schema: Joi.object({
+      collections: Joi.array().items(
+        Joi.object({
+          id: Joi.string().description("Collection id"),
+          name: Joi.string().allow("", null),
+          image: Joi.string().allow("", null),
+          primaryContract: Joi.string().lowercase().pattern(regex.address),
+          count: Joi.number().integer(),
+        })
+      ),
+    }).label(`getTopSellingCollections${version.toUpperCase()}Response`),
+    failAction: (_request, _h, error) => {
+      logger.error(
+        `get-top-selling-collections-${version}-handler`,
+        `Wrong response schema: ${error}`
+      );
+      throw error;
+    },
+  },
+  handler: async (request: Request) => {
+    const { startTime, endTime, fillType, limit } = request.query;
+
+    try {
+      const collections = await getTopSellingCollections({
+        startTime,
+        endTime,
+        fillType,
+        limit,
+      });
+
+      return {
+        collections,
+      };
+    } catch (error) {
+      logger.error(`get-top-selling-collections-${version}-handler`, `Handler failure: ${error}`);
+      throw error;
+    }
+  },
+};

--- a/packages/indexer/src/api/endpoints/collections/index.ts
+++ b/packages/indexer/src/api/endpoints/collections/index.ts
@@ -19,3 +19,4 @@ export * from "@/api/endpoints/collections/post-create-collections-set/v1";
 export * from "@/api/endpoints/collections/get-sources-listings/v1";
 export * from "@/api/endpoints/collections/put-set-collection-community/v1";
 export * from "@/api/endpoints/collections/get-collection-supported-marketplaces/v1";
+export * from "@/api/endpoints/collections/get-top-selling-collections/v1";

--- a/packages/indexer/src/api/routes.ts
+++ b/packages/indexer/src/api/routes.ts
@@ -514,6 +514,13 @@ export const setupRoutes = (server: Server) => {
 
   server.route({
     method: "GET",
+
+    path: "/collections/top-selling/v1",
+    options: collectionsEndpoints.getTopSellingCollectionsOptions,
+  });
+
+  server.route({
+    method: "GET",
     path: "/users/{user}/collections/v1",
     options: collectionsEndpoints.getUserCollectionsV1Options,
   });

--- a/packages/indexer/src/elasticsearch/indexes/activities/base/index.ts
+++ b/packages/indexer/src/elasticsearch/indexes/activities/base/index.ts
@@ -75,6 +75,14 @@ export interface ActivityDocument extends BaseDocument {
   };
 }
 
+export interface CollectionAggregation {
+  id: string;
+  name: string;
+  image: string;
+  primaryAssetContract: string;
+  count: number;
+}
+
 export interface BuildActivityData extends BuildDocumentData {
   id: string;
   type: ActivityType;


### PR DESCRIPTION
Uses the elasticsearch activities endpoint to aggregate sales and mints by collection to return a list of "trending collections"

Pretty basic right now but should be able to get people started 