### PR TITLE
fix: looksrare sales price issues

### DIFF
--- a/packages/indexer/src/sync/events/handlers/looks-rare-v2.ts
+++ b/packages/indexer/src/sync/events/handlers/looks-rare-v2.ts
@@ -298,7 +298,9 @@ export const handleEvents = async (events: EnhancedEvent[], onChainData: OnChain
         const maker = parsedLog.args["feeRecipients"][0].toLowerCase();
         let taker = parsedLog.args["bidUser"].toLowerCase();
         const currency = parsedLog.args["currency"].toLowerCase();
-        let currencyPrice = parsedLog.args["feeAmounts"][0].toString();
+        let currencyPrice = parsedLog.args["feeAmounts"]
+          .reduce((sum: string, current: string) => sum + parseInt(current), 0)
+          .toString();
         const contract = parsedLog.args["collection"].toLowerCase();
 
         // It's might be multiple

--- a/packages/indexer/src/tests/treasure/treasure.test.ts
+++ b/packages/indexer/src/tests/treasure/treasure.test.ts
@@ -1,5 +1,6 @@
 import { config as dotEnvConfig } from "dotenv";
 dotEnvConfig();
+import "@/jobs/index";
 import { getEnhancedEventsFromTx } from "../utils/events";
 import { getEventData } from "../../sync/events/data";
 
@@ -8,15 +9,19 @@ describe("Treasure Sales", () => {
     const testCases = [
       {
         name: "bid",
-        tx: "0x9c7363e882515a4826cec9a80e73aea9980b90d8445c417166dd66511d633ace",
+        tx: "0x789f754ffdb9dfb4d9eacec4ca854168b3d2921971ff9ff6103bc89a7d9aa17e",
       },
     ];
 
     for (let index = 0; index < testCases.length; index++) {
       const testCase = testCases[index];
       const events = await getEnhancedEventsFromTx(testCase.tx);
-      const eventData = getEventData(["treasure-bid-accepted"])[0];
+      //console.log(events);
+      const eventData = getEventData(["looks-rare-v2-taker-bid"])[0];
       const { args } = eventData.abi.parseLog(events[1].log);
+      // console.log(
+      //   args["feeAmounts"].reduce((sum: string, current: string) => sum + parseInt(current), 0)
+      // );
       const maker = args["bidder"].toLowerCase();
       expect(maker).not.toBe(null);
     }


### PR DESCRIPTION
@georgeroman - Not sure this is exactly how you would want to do it, but I think it solves the problem for sales indexing at least. 

Issue - all Lookrare bid acceptances are using the feeRecipient[0] as currency price, when it should be the sum. At least this points out where the issue seems to be. As a result, right now the net price is actually amount to feeRecipient[0] while amount is actually sum of feeRecipients. 

I checked locally on tx: "0x789f754ffdb9dfb4d9eacec4ca854168b3d2921971ff9ff6103bc89a7d9aa17e" and seemed right

Unclear if there would be any impacts outside of just the sales indexing. In orders for example. 

This should require a backfill. 