### PR TITLE
feat: sync events by address and fetch all logs

### DIFF
--- a/packages/indexer/src/api/endpoints/admin/post-sync-events.ts
+++ b/packages/indexer/src/api/endpoints/admin/post-sync-events.ts
@@ -29,6 +29,7 @@ export const postSyncEventsOptions: RouteOptions = {
         Joi.object({
           method: Joi.string().valid("address"),
           address: Joi.string().pattern(regex.address),
+          fetchAllTxLogs: Joi.boolean().default(false),
         })
       ),
       fromBlock: Joi.number().integer().positive().required(),

--- a/packages/indexer/src/jobs/events-sync/events-sync-backfill-job.ts
+++ b/packages/indexer/src/jobs/events-sync/events-sync-backfill-job.ts
@@ -17,6 +17,7 @@ export type ProcessResyncRequestJobPayload = {
     | {
         method: "address";
         address: string;
+        fetchAllTxLogs?: boolean;
       };
   blocksPerBatch?: number;
 };
@@ -64,6 +65,7 @@ export class EventsSyncBackfillJob extends AbstractRabbitMqJobHandler {
         | {
             method: "address";
             address: string;
+            fetchAllTxLogs?: boolean;
           };
     }
   ) {

--- a/packages/indexer/src/jobs/events-sync/process-resync-request-queue-job.ts
+++ b/packages/indexer/src/jobs/events-sync/process-resync-request-queue-job.ts
@@ -14,6 +14,7 @@ export type ProcessResyncRequestJobPayload = {
     | {
         method: "address";
         address: string;
+        fetchAllTxLogs?: boolean;
       };
   blocksPerBatch?: number;
 };
@@ -51,6 +52,7 @@ export class ProcessResyncRequestJob extends AbstractRabbitMqJobHandler {
         | {
             method: "address";
             address: string;
+            fetchAllTxLogs?: boolean;
           };
     }
   ) {


### PR DESCRIPTION
Generally when filtering by and address we want to reduce the amount of events we process/store in the database. However most of the time we are not only interested in the events only emitted by a particular contract, but also in the other events in the transaction. For example, if we want to fetch all the events for particular NFT I would argue that a sale on opensea is also event related to the NFT, but since the orderFullfilled event from seaport is not emitted by the contract address we filter on, we end up ommitting the events. I’ve added a fetchAllTxLogs param to the syncDetail when filtering by address. This will basically perform additional eth_getTransactionReceipt calls for every transactionHash. In some situatioons those calls might be redundant, but most of the time if we are dealing with sales on marketplaces we want the additional events.