### PR TITLE
feat: clarify rarity returned on collection <100k

### DIFF
--- a/packages/indexer/src/api/endpoints/activities/get-user-activity/v6.ts
+++ b/packages/indexer/src/api/endpoints/activities/get-user-activity/v6.ts
@@ -137,8 +137,8 @@ export const getUserActivityV6Options: RouteOptions = {
               value: Joi.number().unsafe().allow(null),
               timestamp: Joi.number().unsafe().allow(null),
             },
-            tokenRarityScore: Joi.number().allow(null),
-            tokenRarityRank: Joi.number().allow(null),
+            tokenRarityScore: Joi.number().allow(null).description("No rarity for collections over 100k"),
+            tokenRarityRank: Joi.number().allow(null).description("No rarity rank for collections over 100k"),
             tokenMedia: Joi.string().allow(null),
           }),
           collection: Joi.object({

--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
@@ -116,11 +116,11 @@ export const getTokensV6Options: RouteOptions = {
       minRarityRank: Joi.number()
         .integer()
         .min(1)
-        .description("Get tokens with a min rarity rank (inclusive)"),
+        .description("Get tokens with a min rarity rank (inclusive), no rarity rank for collections over 100k"),
       maxRarityRank: Joi.number()
         .integer()
         .min(1)
-        .description("Get tokens with a max rarity rank (inclusive)"),
+        .description("Get tokens with a max rarity rank (inclusive), no rarity rank for collections over 100k"),
       minFloorAskPrice: Joi.number().description(
         "Get tokens with a min floor ask price (inclusive); use native currency"
       ),
@@ -136,7 +136,7 @@ export const getTokensV6Options: RouteOptions = {
         .valid("floorAskPrice", "tokenId", "rarity")
         .default("floorAskPrice")
         .description(
-          "Order the items are returned in the response. Options are `floorAskPrice`, `tokenId`, and `rarity`."
+          "Order the items are returned in the response. Options are `floorAskPrice`, `tokenId`, and `rarity`. No rarity rank for collections over 100k."
         ),
       sortDirection: Joi.string().lowercase().valid("asc", "desc"),
       currencies: Joi.alternatives().try(
@@ -221,8 +221,8 @@ export const getTokensV6Options: RouteOptions = {
               .allow(null)
               .description("Can be higher than 1 if erc1155"),
             remainingSupply: Joi.number().unsafe().allow(null),
-            rarity: Joi.number().unsafe().allow(null),
-            rarityRank: Joi.number().unsafe().allow(null),
+            rarity: Joi.number().unsafe().allow(null).description("No rarity for collections over 100k"),
+            rarityRank: Joi.number().unsafe().allow(null).description("No rarity rank for collections over 100k"),
             collection: Joi.object({
               id: Joi.string().allow(null),
               name: Joi.string().allow("", null),

--- a/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v7.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v7.ts
@@ -151,8 +151,8 @@ export const getUserTokensV7Options: RouteOptions = {
               .allow(null)
               .description("Can be higher than one if erc1155."),
             remainingSupply: Joi.number().unsafe().allow(null),
-            rarityScore: Joi.number().allow(null),
-            rarityRank: Joi.number().allow(null),
+            rarityScore: Joi.number().allow(null).description("No rarity for collections over 100k"),
+            rarityRank: Joi.number().allow(null).description("No rarity rank for collections over 100k"),
             media: Joi.string().allow(null),
             collection: Joi.object({
               id: Joi.string().allow(null),


### PR DESCRIPTION
Added description to clarify rarity will be returned for collections with less than 100k tokens.