### PR TITLE
feat: clarify sortBy corresponding sortDirection

### DIFF
--- a/packages/indexer/src/api/endpoints/orders/get-orders-asks/v5.ts
+++ b/packages/indexer/src/api/endpoints/orders/get-orders-asks/v5.ts
@@ -145,7 +145,7 @@ export const getOrdersAsksV5Options: RouteOptions = {
         .valid("createdAt", "price", "updatedAt")
         .default("createdAt")
         .description(
-          "Order the items are returned in the response, Sorting by price allowed only when filtering by token"
+          "Order the items are returned in the response. Sorting by `price` allowed only when filtering by token & is ascending order."
         ),
       sortDirection: Joi.string()
         .lowercase()

--- a/packages/indexer/src/api/endpoints/orders/get-orders-bids/v6.ts
+++ b/packages/indexer/src/api/endpoints/orders/get-orders-bids/v6.ts
@@ -32,7 +32,7 @@ const version = "v6";
 export const getOrdersBidsV6Options: RouteOptions = {
   description: "Bids (offers)",
   notes:
-    "Get a list of bids (offers), filtered by token, collection or maker. This API is designed for efficiently ingesting large volumes of orders, for external processing.\n\n- There are a different kind of bids than can be returned:\n\n To get all orders unflitered, select `sortBy` to `updatedAt`. No need to pass any other param. This will return any orders for any collections, token, attribute, etc. \n\n- Inputting a 'contract' will return token and attribute bids.\n\n- Inputting a 'collection-id' will return collection wide bids./n/n- Please mark `excludeEOA` as `true` to exclude Blur orders.",
+  "Get a list of bids (offers), filtered by token, collection or maker. This API is designed for efficiently ingesting large volumes of orders, for external processing.\n\n There are a different kind of bids than can be returned:\n\n- To get all orders unfiltered, select `sortBy` to `updatedAt`. No need to pass any other param. This will return any orders for any collections, token, attribute, etc. \n\n- Inputting a 'contract' will return token and attribute bids.\n\n- Inputting a 'collection-id' will return collection wide bids.\n\n- Please mark `excludeEOA` as `true` to exclude Blur orders.",
   tags: ["api", "Orders"],
   plugins: {
     "hapi-swagger": {

--- a/packages/indexer/src/api/endpoints/orders/get-orders-bids/v6.ts
+++ b/packages/indexer/src/api/endpoints/orders/get-orders-bids/v6.ts
@@ -168,7 +168,7 @@ export const getOrdersBidsV6Options: RouteOptions = {
       sortBy: Joi.string()
         .valid("createdAt", "price", "updatedAt")
         .default("createdAt")
-        .description("Order the items are returned in the response."),
+        .description("Order the items are returned in the response. Sorting by `price` defaults sorting direction to descending. "),
       sortDirection: Joi.string()
         .lowercase()
         .when("sortBy", {


### PR DESCRIPTION
Clarify for order/bids and order/asks what sortDirection is default when sortBy=price
- Asks sortBy=price, sortDirection=asc
- Bids sortBy=price, sortDirection=desc