### PR TITLE
feat: ditto router module and sdk

### DIFF
--- a/packages/contracts/contracts/interfaces/IDittoPool.sol
+++ b/packages/contracts/contracts/interfaces/IDittoPool.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IDittoPool {
+
+    /**
+     * @param nftIds The list of IDs of the NFTs to purchase
+     * @param maxExpectedTokenInput The maximum acceptable cost from the sender (in wei or base units of ERC20).
+     *   If the actual amount is greater than this value, the transaction will be reverted.
+     * @param tokenSender ERC20 sender. Only used if msg.sender is an approved IDittoRouter, else msg.sender is used.
+     * @param nftRecipient Address to send the purchased NFTs to.
+     */
+    struct SwapTokensForNftsArgs {
+        uint256[] nftIds;
+        uint256 maxExpectedTokenInput;
+        address tokenSender;
+        address nftRecipient;
+        bytes swapData;
+    }
+
+    /**
+     * @param nftIds The list of IDs of the NFTs to sell to the pair
+     * @param lpIds The list of IDs of the LP positions sell the NFTs to
+     * @param minExpectedTokenOutput The minimum acceptable token count received by the sender. 
+     *   If the actual amount is less than this value, the transaction will be reverted.
+     * @param nftSender NFT sender. Only used if msg.sender is an approved IDittoRouter, else msg.sender is used.
+     * @param tokenRecipient The recipient of the ERC20 proceeds.
+     * @param permitterData Data to profe that the NFT Token IDs are permitted to be sold to this pool if a permitter is set.
+     * @param swapData Extra data to pass to the curve
+     */
+    struct SwapNftsForTokensArgs {
+        uint256[] nftIds;
+        uint256[] lpIds;
+        uint256 minExpectedTokenOutput;
+        address nftSender;
+        address tokenRecipient;
+        bytes permitterData;
+        bytes swapData;
+    }
+
+    function token() external returns (IERC20);
+
+    function swapNftsForTokens(
+        SwapNftsForTokensArgs calldata args_
+    ) external returns (uint256 outputAmount);
+
+    function swapTokensForNfts(
+        SwapTokensForNftsArgs calldata args_
+    ) external returns (uint256 inputAmount);
+
+}

--- a/packages/contracts/contracts/router/modules/exchanges/DittoModule.sol
+++ b/packages/contracts/contracts/router/modules/exchanges/DittoModule.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {BaseExchangeModule} from "./BaseExchangeModule.sol";
+import {BaseModule} from "../BaseModule.sol";
+import {IDittoPool} from "../../../interfaces/IDittoPool.sol";
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {SafeTransferLib} from "solmate/src/utils/SafeTransferLib.sol";
+
+struct DittoOrderParams {
+  uint256[] nftIds;
+  bytes swapData;
+}
+
+contract DittoModule is BaseExchangeModule {
+  using SafeTransferLib for ERC20;
+
+  // --- Constructor ---
+  constructor(address owner, address router) BaseModule(owner) BaseExchangeModule(router) {}
+
+  function poolTransferNftFrom(
+    IERC721 nft, 
+    address from, 
+    address to, 
+    uint256 id
+  ) 
+  external 
+  {
+      // transfer NFTs to pool
+      nft.transferFrom(from, to, id);
+  }
+
+  function poolTransferErc20From(
+    ERC20 token,
+    address from,  
+    address to,
+    uint256 amount
+  ) 
+  external 
+  virtual 
+  {
+    // transfer tokens to txn sender
+    token.safeTransferFrom(from, to, amount);
+  }
+
+  // --- Multiple ERC20 listing ---
+
+  function buyWithERC20(
+    IDittoPool[] calldata pairs,
+    DittoOrderParams[] calldata orderParams,
+    ERC20ListingParams calldata params,
+    Fee[] calldata fees
+  )
+  external
+  nonReentrant
+  refundERC20Leftover(params.refundTo, params.token)
+  chargeERC20Fees(fees, params.token, params.amount)
+  {
+    uint256 pairsLength = pairs.length;
+    for (uint256 i; i < pairsLength; ) {
+
+      // Execute fill
+      IDittoPool.SwapTokensForNftsArgs memory args = IDittoPool.SwapTokensForNftsArgs({
+        nftIds: orderParams[i].nftIds,
+        maxExpectedTokenInput: params.amount,
+        tokenSender: params.fillTo,
+        nftRecipient: params.fillTo,
+        swapData: orderParams[i].swapData
+      }); 
+
+      pairs[i].swapTokensForNfts(args);
+
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  // --- Single ERC721 offer ---
+
+  function sell(
+    IDittoPool pool,
+    DittoOrderParams calldata orderParams,
+    uint256[] calldata lpIds,
+    bytes calldata permitterData,
+    uint256 minOutput,
+    OfferParams calldata params,
+    Fee[] calldata fees
+  ) external nonReentrant {
+  
+      IERC20 token = pool.token();
+
+      IDittoPool.SwapNftsForTokensArgs memory args = IDittoPool.SwapNftsForTokensArgs({
+        nftIds: orderParams.nftIds,
+        lpIds: lpIds,
+        minExpectedTokenOutput: minOutput,
+        nftSender: params.fillTo,
+        tokenRecipient: params.fillTo,
+        permitterData: permitterData,
+        swapData: orderParams.swapData
+      });
+
+      pool.swapNftsForTokens(args);
+
+      // Pay fees
+      uint256 feesLength = fees.length;
+      for (uint256 i; i < feesLength; ) {
+        Fee memory fee = fees[i];
+        _sendERC20(fee.recipient, fee.amount, token);
+
+        unchecked {
+          ++i;
+        }
+      }
+  }
+  
+}

--- a/packages/contracts/test/router/ditto/listings-oracle.test.ts
+++ b/packages/contracts/test/router/ditto/listings-oracle.test.ts
@@ -1,0 +1,236 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { ethers } from "hardhat";
+import { BigNumber } from "@ethersproject/bignumber";
+import { expect } from "chai";
+import abiDittoAppraisal from "../../../../sdk/src/ditto/abis/DittoPoolApp.json";
+import abiUpshotOracle from "../../../../sdk/src/ditto/abis/UpshotOracle.json";
+import { getDittoContracts } from "../helpers/ditto";
+import { Bytes } from "ethers";
+
+import * as Sdk from "../../../../sdk/src";
+
+/**
+ * run with the following command:
+ *
+ * BLOCK_NUMBER="9268037" npx hardhat test test/router/ditto/listings-oracle.test.ts
+ */
+describe("DittoModule", () => {
+  let initialTokenBalance: BigNumber;
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+
+  let nft: Contract;
+  let token: Contract;
+  let dittoPoolFactory: Contract;
+
+  let router: Contract;
+  let dittoModule: Contract;
+
+  beforeEach(async () => {
+    [deployer] = await ethers.getSigners();
+
+    const dittoContracts  = getDittoContracts()
+    nft = dittoContracts.nft
+    token = dittoContracts.token
+    dittoPoolFactory = dittoContracts.dittoPoolFactory
+
+    let adminAddress = "0x00000000000000000000000000000000DeaDBeef";
+    alice = await ethers.getImpersonatedSigner(adminAddress);
+
+    initialTokenBalance =  ethers.utils.parseEther("10");
+
+    router = await ethers
+      .getContractFactory("ReservoirV6_0_1", deployer)
+      .then((factory) => factory.deploy());
+
+    dittoModule = await ethers
+      .getContractFactory("DittoModule", deployer)
+      .then((factory) => factory.deploy(deployer.address, router.address));
+
+    const ownerAddress: string = await dittoPoolFactory.owner();
+    const ownerSigner: SignerWithAddress = await ethers.getImpersonatedSigner(ownerAddress);
+    await dittoPoolFactory.connect(ownerSigner).addRouters([dittoModule.address]);
+  });
+
+  it("Upshot oracle test", async () => {
+    // pick a random token id that hasn't yet been minted on goerli
+    const tokenId04 = ethers.utils.keccak256("0xdeadbeef");
+
+    // mint alice some NFTs and tokens to do trading with.
+    await nft.connect(alice).mint(alice.address, tokenId04);
+    await nft.connect(alice).setApprovalForAll(dittoPoolFactory.address, true);
+    await token.connect(alice).mint(alice.address, parseEther("100"));
+    await token.connect(alice).approve(dittoPoolFactory.address, parseEther("100"));
+    let approve = await token.connect(alice).approve(dittoModule.address, parseEther("100"));
+    await approve.wait();
+
+    // sanity checks
+    await token.balanceOf(alice.address).then((balance: any) => {
+      expect(balance).to.equal(parseEther("100"));
+    });
+
+    await nft.ownerOf(tokenId04).then((owner: string) => {
+      expect(owner).to.equal(alice.address);
+    });
+
+    // set up the oracle contract for the test
+    const upshotOracle: Contract = new Contract(
+      Sdk.Ditto.Addresses.UpshotOracle[5],
+      abiUpshotOracle,
+      ethers.provider
+    );
+    const oracleOwnerAddress = await upshotOracle.owner();
+    const oracleOwnerSigner: SignerWithAddress = await ethers.getImpersonatedSigner(
+      oracleOwnerAddress
+    );
+    // make it easier for us to forge appraisals for testing with
+    await upshotOracle.connect(oracleOwnerSigner).setAuthenticator(deployer.address);
+
+    // set params for creating a pool
+    const isPrivatePool = false; // allow any member of the public to provide liquidity to this pool
+    const templateIndex = 6; //DittoPoolApp
+    const tokenAddress = token.address; // which ERC20 we are trading
+    const nftAddress = nft.address; // which NFT we are trading
+    const feeLp = 0; // The percentage fee paid to the LP provider for their service of providing liquidity
+    const ownerAddress = alice.address; // the owner of the pool for pool administrative tasks
+    const feeAdmin = 0; // The percentage fee paid to the pool admin for their service of administrating the pool
+    const delta = 0; // Unused in appraisal pools
+    const basePrice = 0; // Unused in appraisal pools
+    const nftIdList: any[] = [tokenId04]; // initial liquidity deposit of token 4
+    const initialTokenBalance = ethers.utils.parseEther("1"); // inital liquidity deposit of 1 ether
+    // the inital template for creating a ditto appraisal pool takes 3 parameters:
+    // first, the address of the oracle to be used for this appraisal pool
+    // then as safety guardrail for the range at which a pool should ignore appraisal prices
+    // and never sell. E.g.:
+    // The minPriceSell to never sell an NFT for less than
+    // and the maxPriceBuy to never buy an NFT for more than
+    // for this example we set that to 1 wei and 10 ether respectively, so an appraisal will be ignored
+    // if it's for sale for more than 10 ether or less than 1 wei, even if 
+    // the appraisal is validly signed by the upshot oracle
+    const templateInitData: any = ethers.utils.defaultAbiCoder.encode(
+      ["address", "uint256", "uint256"],
+      [Sdk.Ditto.Addresses.UpshotOracle[5], "1", ethers.utils.parseEther("10")]
+    );
+    const referrer: any = new Uint8Array([]); // used with ditto referral program.
+
+    const poolTemplate: any = {
+      isPrivatePool: isPrivatePool,
+      templateIndex: templateIndex,
+      token: tokenAddress,
+      nft: nftAddress,
+      feeLp: feeLp,
+      owner: ownerAddress,
+      feeAdmin: feeAdmin,
+      delta: delta,
+      basePrice: basePrice,
+      nftIdList: nftIdList,
+      initialTokenBalance: initialTokenBalance,
+      templateInitData: templateInitData,
+      referrer: referrer,
+    };
+
+    // we do not use a pool manager for this pool
+    const mngrTemplateIndex = ethers.constants.MaxUint256
+    const mngrInitData = new Uint8Array([]);
+    const poolManagerTemplate: any = {
+      templateIndex: mngrTemplateIndex,
+      templateInitData: mngrInitData,
+    };
+
+    // nor do we use a pool permitter
+    const permitterTemplateIndex = ethers.constants.MaxUint256
+    const permitterInitData = new Uint8Array([]);
+    const liquidityDepositPermissionData = new Uint8Array([]);
+    const permitterTemplate = {
+      templateIndex: permitterTemplateIndex,
+      templateInitData: permitterInitData,
+      liquidityDepositPermissionData: liquidityDepositPermissionData,
+    };
+
+    // create the pool
+    const poolCreateTxn = await dittoPoolFactory
+      .connect(deployer)
+      .createDittoPool(poolTemplate, poolManagerTemplate, permitterTemplate);
+    let output = await poolCreateTxn.wait();
+
+    // find out the address of the newly created pool for further transactions
+    const event: any = output.events.find(
+      (event: { event: string }) => event.event === "DittoPoolFactoryDittoPoolCreated"
+    );
+    const dpAddress = event.args.dittoPool;
+    const dittoPool: Contract = new Contract(dpAddress, abiDittoAppraisal, ethers.provider);
+
+    // now approve the pool for further trading 
+    await token.connect(alice).approve(dittoPool.address, parseEther("100"));
+
+    // sanity check
+    const oracleAddress: any = await dittoPool.oracle();
+    expect(oracleAddress).to.eq(Sdk.Ditto.Addresses.UpshotOracle[5]);
+    
+
+    // construct an appraisal like you would get from the upshot appraisal API
+    const chainId = 5;
+    const nonce = BigNumber.from(1);
+    // Fri Jan 01 2016 05:00:00 GMT+0000
+    const timestamp = BigNumber.from("1451624400");
+    // Wed Dec 30 2099 00:00:00 GMT+0000
+    const expiration = BigNumber.from("4102272000");
+    const price = ethers.utils.parseEther("1");
+    const extraData: Bytes = []
+    // create a signature for this appraisal
+    let messageHash = ethers.utils.solidityKeccak256(
+      ["uint256", "uint256", "address", "uint256", "address", "uint256", "uint96", "uint96", "bytes"],
+      [chainId, nonce, nft.address, tokenId04, token.address, price, timestamp, expiration, extraData]
+    );
+    let messageHashBytes = ethers.utils.arrayify(messageHash);
+    let flatSig = await deployer.signMessage(messageHashBytes);
+
+    // appraisal in struct form
+    const priceData: any = {
+      signature: flatSig,
+      nonce: nonce,
+      nft: nft.address,
+      timestamp: timestamp,
+      token: token.address,
+      expiration: expiration,
+      nftId: tokenId04,
+      price: price,
+      extraData: extraData,
+    };
+
+    const swapData = ethers.utils.defaultAbiCoder.encode(
+      [
+        "tuple(bytes signature,uint256 nonce,address nft,uint96 timestamp,address token,uint96 expiration,uint256 nftId,uint256 price,bytes extraData)[]",
+      ],
+      [[priceData]]
+    );
+
+    const fillTo: string = alice.address;
+    const refundTo: string = alice.address;
+    const revertIfIncomplete: boolean = false;
+    const amountPayment: BigNumber = parseEther("1.2");
+
+    const eRC20ListingParams = [fillTo, refundTo, revertIfIncomplete, tokenAddress, amountPayment];
+
+    const recipient: string = dittoPool.address;
+    const amountFee: BigNumber = parseEther("0");
+
+    const fee = [recipient, amountFee];
+
+    const orderParams = [[tokenId04], swapData];
+
+    const buyWithERC20 = [[dittoPool.address], [orderParams], eRC20ListingParams, [fee]];
+
+    let data = dittoModule.interface.encodeFunctionData("buyWithERC20", buyWithERC20);
+
+    const executions = [dittoModule.address, data, 0];
+
+    await router.execute([executions]);
+
+    await nft.ownerOf(tokenId04).then((owner: any) => {
+      expect(owner).to.eq(fillTo);
+    });
+  });
+});

--- a/packages/contracts/test/router/ditto/listings.test.ts
+++ b/packages/contracts/test/router/ditto/listings.test.ts
@@ -1,0 +1,141 @@
+import { Contract, ContractReceipt } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { ethers } from "hardhat";
+import { BigNumber } from "@ethersproject/bignumber";
+import { expect } from "chai";
+import { getDittoContracts } from "../helpers/ditto";
+import abiDittoPool from "../../../../sdk/src/ditto/abis/DittoPool.json";
+
+/**
+ * run with the following command:
+ *
+ * BLOCK_NUMBER="9268037" npx hardhat test test/router/ditto/listings.test.ts
+ */
+describe("DittoModule", () => {
+  let poolAddress: string;
+  let initialTokenBalance: BigNumber;
+  let deployer: SignerWithAddress;
+  let marketMaker: SignerWithAddress;
+  const traderAddress = "0x00000000000000000000000000000000DeaDBeef";
+  let trader: SignerWithAddress;
+
+  let nft: Contract;
+  let token: Contract;
+  let dittoPool: Contract;
+  let dittoPoolFactory: Contract;
+
+  let router: Contract;
+  let dittoModule: Contract;
+  // random numbers that aren't likely to already have been minted
+  const tokenId00 = ethers.BigNumber.from("0x13376969420123");
+  const tokenId01 = ethers.BigNumber.from("0x13376969420124");
+
+  beforeEach(async () => {
+    ({ nft, token, dittoPoolFactory } = getDittoContracts());
+    trader = await ethers.getImpersonatedSigner(traderAddress);
+    [deployer, marketMaker] = await ethers.getSigners();
+    initialTokenBalance = parseEther("1000");
+
+    router = await ethers
+      .getContractFactory("ReservoirV6_0_1", deployer)
+      .then((factory) => factory.deploy());
+    dittoModule = await ethers
+      .getContractFactory("DittoModule", deployer)
+      .then((factory) => factory.deploy(deployer.address, router.address));
+    const ownerAddress: string = await dittoPoolFactory.owner();
+    const ownerSigner: SignerWithAddress = await ethers.getImpersonatedSigner(ownerAddress);
+    await dittoPoolFactory.connect(ownerSigner).addRouters([dittoModule.address]);
+    // mint the NFTs to the market maker
+    await nft.connect(marketMaker).mint(marketMaker.address, tokenId00);
+    await nft.connect(marketMaker).mint(marketMaker.address, tokenId01);
+    await nft.connect(marketMaker).setApprovalForAll(dittoPoolFactory.address, true);
+
+    //create a pool to trade with, with the NFTs deposited into the pool
+
+    const poolTemplate = {
+      isPrivatePool: false,
+      templateIndex: 3, // LINEAR
+      token: token.address,
+      nft: nft.address,
+      feeLp: 0,
+      owner: marketMaker.address,
+      feeAdmin: 0,
+      delta: ethers.utils.parseEther("1.01"),
+      basePrice: ethers.utils.parseEther("1"),
+      nftIdList: [tokenId00, tokenId01],
+      initialTokenBalance: 0,
+      templateInitData: "0x",
+      referrer: "0x",
+    };
+    const poolManagerTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+    };
+    const permitterTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+      liquidityDepositPermissionData: "0x",
+    };
+    const creation = await dittoPoolFactory
+      .connect(marketMaker)
+      .createDittoPool(poolTemplate, poolManagerTemplate, permitterTemplate);
+    const result: ContractReceipt = await creation.wait();
+    result.events!.forEach((event) => {
+      if (event.event === "DittoPoolFactoryDittoPoolCreated") {
+        poolAddress = event.args!.dittoPool;
+      }
+    });
+    dittoPool = new ethers.Contract(poolAddress, abiDittoPool, trader);
+  });
+
+  it("Accept multiple listings", async () => {
+    await nft.ownerOf(tokenId00).then((owner: any) => {
+      expect(owner).to.eq(poolAddress);
+    });
+    await nft.ownerOf(tokenId01).then((owner: any) => {
+      expect(owner).to.eq(poolAddress);
+    });
+
+    await token.connect(trader).mint(traderAddress, initialTokenBalance);
+    await token.balanceOf(traderAddress).then((balance: BigNumber) => {
+      expect(balance).to.equal(initialTokenBalance);
+    });
+    let approve = await token.connect(trader).approve(dittoModule.address, initialTokenBalance);
+    await approve.wait();
+
+    // Fetch the current price
+    let result = await dittoPool.getBuyNftQuote(2, "0x");
+    let inputValue = result[3];
+
+    const fillTo: string = traderAddress;
+    const refundTo: string = traderAddress;
+    const revertIfIncomplete: boolean = false;
+    const tokenAddress: string = token.address;
+    const amountPayment: BigNumber = inputValue;
+
+    const eRC20ListingParams = [fillTo, refundTo, revertIfIncomplete, tokenAddress, amountPayment];
+
+    const recipient: string = dittoPool.address;
+    const amountFee: BigNumber = parseEther("0");
+
+    const fee = [recipient, amountFee];
+
+    const orderParams = [[tokenId00, tokenId01], "0x"];
+
+    const buyWithERC20 = [[dittoPool.address], [orderParams], eRC20ListingParams, [fee]];
+
+    let data = dittoModule.interface.encodeFunctionData("buyWithERC20", buyWithERC20);
+
+    const executions = [dittoModule.address, data, 0];
+
+    await router.execute([executions]);
+
+    await nft.ownerOf(tokenId00).then((owner: any) => {
+      expect(owner).to.eq(fillTo);
+    });
+    await nft.ownerOf(tokenId01).then((owner: any) => {
+      expect(owner).to.eq(fillTo);
+    });
+  });
+});

--- a/packages/contracts/test/router/ditto/offers.test.ts
+++ b/packages/contracts/test/router/ditto/offers.test.ts
@@ -1,0 +1,174 @@
+import { Contract, ContractReceipt } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { ethers } from "hardhat";
+import { BigNumber } from "@ethersproject/bignumber";
+import { expect, assert } from "chai";
+import { getDittoContracts } from "../helpers/ditto";
+import abiDittoPool from "../../../../sdk/src/ditto/abis/DittoPool.json";
+import { constructPrivateListingCounterOrder } from "@reservoir0x/sdk/src/seaport-base/helpers";
+
+/**
+ * run with the following command:
+ *
+ * BLOCK_NUMBER="9268037" npx hardhat test test/router/ditto/offers.test.ts
+ */
+describe("DittoModule", () => {
+  let initialTokenBalance: BigNumber;
+  let deployer: SignerWithAddress;
+  let marketMaker: SignerWithAddress;
+  let marketMakerAddress: string;
+  let trader: SignerWithAddress;
+  let traderAddress: string;
+  let poolAddress: string;
+  let dittoPool: Contract;
+
+  let marketMakerLpId: BigNumber;
+
+  let nft: Contract;
+  let token: Contract;
+  let dittoPoolFactory: Contract;
+
+  let router: Contract;
+  let dittoModule: Contract;
+
+  beforeEach(async () => {
+    ({ nft, token, dittoPoolFactory } = getDittoContracts());
+
+    marketMakerAddress = "0x00000000000000000000000000000000DeaDBeef";
+    marketMaker = await ethers.getImpersonatedSigner(marketMakerAddress);
+    traderAddress = "0x00000000000000000000000000000000cafebabe";
+    trader = await ethers.getImpersonatedSigner(traderAddress);
+
+    [deployer] = await ethers.getSigners();
+
+    initialTokenBalance = parseEther("100");
+
+    // deploy and whitelist reservoir module in Ditto protocol
+    router = await ethers
+      .getContractFactory("ReservoirV6_0_1", deployer)
+      .then((factory) => factory.deploy());
+
+    dittoModule = await ethers
+      .getContractFactory("DittoModule", deployer)
+      .then((factory) => factory.deploy(deployer.address, router.address));
+
+    const dittoDeployerAddress: string = await dittoPoolFactory.connect(deployer).owner();
+    const dittoDeployer: SignerWithAddress = await ethers.getImpersonatedSigner(
+      dittoDeployerAddress
+    );
+    await dittoPoolFactory.connect(dittoDeployer).addRouters([dittoModule.address]);
+
+    // Create a ditto pool with some tokens in it to buy NFTs with, but no NFTs
+    await token.connect(marketMaker).mint(marketMakerAddress, initialTokenBalance);
+    await token.balanceOf(marketMakerAddress).then((balance: BigNumber) => {
+      assert(balance.eq(initialTokenBalance), "market maker does not have initial token balance");
+    });
+    await token.connect(marketMaker).approve(dittoPoolFactory.address, initialTokenBalance);
+
+    const poolTemplate = {
+      isPrivatePool: false,
+      templateIndex: 3, // DittoPoolLin
+      token: token.address,
+      nft: nft.address,
+      feeLp: 0,
+      owner: marketMakerAddress,
+      feeAdmin: 0,
+      delta: parseEther("0.1"),
+      basePrice: parseEther("1"),
+      nftIdList: [],
+      initialTokenBalance: initialTokenBalance,
+      templateInitData: "0x",
+      referrer: "0x",
+    };
+
+    const poolManagerTemplate: any = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+    };
+
+    const permitterTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+      liquidityDepositPermissionData: "0x",
+    };
+
+    const createDittoPoolTxn = await dittoPoolFactory
+      .connect(marketMaker)
+      .createDittoPool(poolTemplate, poolManagerTemplate, permitterTemplate);
+    let createDittoPoolReceipt: ContractReceipt = await createDittoPoolTxn.wait();
+
+    // from the creation transaction, get the new pool address and the LP ID for the position
+    const dittoPoolInterface = new ethers.utils.Interface(abiDittoPool);
+    createDittoPoolReceipt.events!.forEach((event) => {
+      if (event.event === "DittoPoolFactoryDittoPoolCreated") {
+        poolAddress = event.args!.dittoPool;
+      }
+    });
+    createDittoPoolReceipt.logs.forEach((log) => {
+      try {
+        const event = dittoPoolInterface.parseLog(log);
+        if (event.name === "DittoPoolMarketMakeLiquidityCreated") {
+          marketMakerLpId = event.args!.lpId;
+        }
+      } catch (e) {
+        return;
+      }
+    });
+
+    dittoPool = new Contract(poolAddress, dittoPoolInterface, ethers.provider);
+  });
+
+  it("Sell an NFT into a pool", async () => {
+    const tokenId00 = 130019123456789; // probably not minted yet
+    await nft.connect(trader).mint(traderAddress, tokenId00);
+    await nft.ownerOf(tokenId00).then((owner: string) => {
+      expect(owner).to.eq(traderAddress);
+    });
+    await nft.connect(trader).setApprovalForAll(dittoModule.address, true);
+    const traderInitialBalance = await token.balanceOf(traderAddress);
+
+    const sellQuote = await dittoPool.getSellNftQuote(1, "0x");
+    let outputValue = sellQuote[3];
+
+    const fee = [poolAddress, 0];
+
+    const orderParams = {
+      nftIds: [tokenId00],
+      swapData: "0x",
+    };
+
+    const offerParams = {
+      fillTo: traderAddress,
+      refundTo: traderAddress,
+      revertIfIncomplete: false,
+    };
+
+    const sell = [
+      poolAddress,
+      orderParams,
+      [marketMakerLpId.toString()],
+      "0x",
+      outputValue,
+      offerParams,
+      [fee],
+    ];
+
+    let data = dittoModule.interface.encodeFunctionData("sell", sell);
+
+    const executions = [dittoModule.address, data, 0];
+
+    await router.execute([executions]);
+
+    await nft.ownerOf(tokenId00).then((owner: any) => {
+      expect(owner).to.eq(poolAddress);
+    });
+
+    const traderFinalBalance = await token.balanceOf(traderAddress);
+    assert(traderFinalBalance.gt(traderInitialBalance), "trader balance should be greater");
+    assert(
+      traderFinalBalance.eq(traderInitialBalance.add(outputValue)),
+      "trader balance should be greater by exactly output value"
+    );
+  });
+});

--- a/packages/contracts/test/router/helpers/ditto.ts
+++ b/packages/contracts/test/router/helpers/ditto.ts
@@ -1,0 +1,36 @@
+import { Contract } from "@ethersproject/contracts";
+
+import { ethers } from "hardhat";
+
+import * as Sdk from "../../../../sdk/src";
+import abiErc20 from "../../../../sdk/src/common/abis/Erc20.json";
+import abiErc721 from "../../../../sdk/src/common/abis/Erc721.json";
+import abiDittoPoolFactory from "../../../../sdk/src/ditto/abis/DittoPoolFactory.json";
+import { getChainId } from "../../utils";
+
+export const getDittoContracts = () => {
+  const chainId = getChainId();
+
+  const testNftAddress =  Sdk.Ditto.Addresses.Test721[chainId];
+  const nft: Contract = new Contract(
+    testNftAddress,
+    abiErc721,
+    ethers.provider
+  );
+
+  const testTokenAddress = Sdk.Ditto.Addresses.Test20[chainId];
+  const token: Contract = new Contract(
+    testTokenAddress,
+    abiErc20,
+    ethers.provider
+  );
+
+  const dittoPoolFactoryAddress =  Sdk.Ditto.Addresses.DittoPoolFactory[chainId];
+  const dittoPoolFactory: Contract = new Contract(
+    dittoPoolFactoryAddress,
+    abiDittoPoolFactory,
+    ethers.provider
+  );
+
+  return { nft, token, dittoPoolFactory };
+};

--- a/packages/contracts/test/sdk/ditto/order.test.ts
+++ b/packages/contracts/test/sdk/ditto/order.test.ts
@@ -1,0 +1,146 @@
+import { Contract } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { ethers } from "hardhat";
+import { getDittoContracts } from "../../router/helpers/ditto";
+import { ContractReceipt } from "ethers";
+import { getChainId, reset } from "../../utils";
+import { expect } from "chai";
+import abiDittoPool from "../../../../sdk/src/ditto/abis/DittoPool.json";
+
+import * as Ditto from "@reservoir0x/sdk/src/ditto";
+
+describe("Ditto Reservoir SDK support", () => {
+  const chainId = getChainId();
+  let deployer: SignerWithAddress;
+  let poolAddress: string;
+  let marketMaker: SignerWithAddress;
+  const traderAddress = "0x00000000000000000000000000000000DeaDBeef";
+  let trader: SignerWithAddress;
+  let nft: Contract;
+  let token: Contract;
+  let dittoPool: Contract;
+  let dittoPoolFactory: Contract;
+  let router: Contract;
+  let dittoModule: Contract;
+  // random numbers that aren't likely to already have been minted
+  const tokenId00 = ethers.BigNumber.from("0x13376969420123");
+  const tokenId01 = ethers.BigNumber.from("0x13376969420124");
+
+  let sdkRouter: Ditto.Router;
+
+  beforeEach(async () => {
+    ({ nft, token, dittoPoolFactory } = getDittoContracts());
+    trader = await ethers.getImpersonatedSigner(traderAddress);
+    [deployer, marketMaker] = await ethers.getSigners();
+
+    router = await ethers
+      .getContractFactory("ReservoirV6_0_1", deployer)
+      .then((factory) => factory.deploy());
+    dittoModule = await ethers
+      .getContractFactory("DittoModule", deployer)
+      .then((factory) => factory.deploy(deployer.address, router.address));
+    const ownerAddress: string = await dittoPoolFactory.owner();
+    const ownerSigner: SignerWithAddress = await ethers.getImpersonatedSigner(ownerAddress);
+    await dittoPoolFactory.connect(ownerSigner).addRouters([dittoModule.address]);
+    // mint the NFTs to the market maker
+    await nft.connect(marketMaker).mint(marketMaker.address, tokenId00);
+    await nft.connect(marketMaker).setApprovalForAll(dittoPoolFactory.address, true);
+    await token.connect(marketMaker).mint(marketMaker.address, parseEther("1000"));
+    await token.connect(marketMaker).approve(dittoPoolFactory.address, parseEther("1"));
+    // mint tokens to the trader
+    await token.connect(trader).mint(trader.address, parseEther("1000"));
+    await nft.connect(trader).mint(trader.address, tokenId01);
+
+    //create a pool to trade with, with the NFTs deposited into the pool
+    // the pool will have one NFT in it (tokenId00)
+    // and 1 eth in it
+    const poolTemplate = {
+      isPrivatePool: false,
+      templateIndex: 3, // LINEAR
+      token: token.address,
+      nft: nft.address,
+      feeLp: 0,
+      owner: marketMaker.address,
+      feeAdmin: 0,
+      delta: ethers.utils.parseEther("0.01"),
+      basePrice: ethers.utils.parseEther("1"),
+      nftIdList: [tokenId00],
+      initialTokenBalance: ethers.utils.parseEther("1"),
+      templateInitData: "0x",
+      referrer: "0x",
+    };
+    const poolManagerTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+    };
+    const permitterTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+      liquidityDepositPermissionData: "0x",
+    };
+    const creation = await dittoPoolFactory
+      .connect(marketMaker)
+      .createDittoPool(poolTemplate, poolManagerTemplate, permitterTemplate);
+    const result: ContractReceipt = await creation.wait();
+    result.events!.forEach((event) => {
+      if (event.event === "DittoPoolFactoryDittoPoolCreated") {
+        poolAddress = event.args!.dittoPool;
+      }
+    });
+    dittoPool = new ethers.Contract(poolAddress, abiDittoPool, trader);
+
+    sdkRouter = new Ditto.Router(chainId);
+  });
+
+  afterEach(reset);
+
+  it("Check fill buy order", async () => {
+    await nft.ownerOf(tokenId00).then((owner: any) => {
+      expect(owner).to.eq(poolAddress);
+    });
+    const orderParams: Ditto.OrderParams = {
+      pool: poolAddress,
+      recipient: trader.address,
+      nftIds: [tokenId00],
+      expectedTokenAmount: ethers.constants.MaxUint256,
+      swapData: "0x",
+    };
+    await token
+      .connect(trader)
+      .approve(Ditto.Addresses.DittoPoolRouterRoyalties[chainId], ethers.constants.MaxUint256);
+    const order = new Ditto.Order(chainId, orderParams);
+    await sdkRouter.fillBuyOrder(trader, order);
+
+    await nft.ownerOf(tokenId00).then((owner: any) => {
+      expect(owner).to.eq(trader.address);
+    });
+  });
+
+  it("Check fill sell order", async () => {
+    await nft.ownerOf(tokenId01).then((owner: any) => {
+      expect(owner).to.eq(trader.address);
+    });
+    const lpIds = await dittoPool.getAllPoolLpIds();
+    const lpId = lpIds[0];
+    const orderParams: Ditto.OrderParams = {
+      pool: poolAddress,
+      recipient: trader.address,
+      nftIds: [tokenId01],
+      lpIds: [lpId],
+      expectedTokenAmount: ethers.constants.Zero,
+      swapData: "0x",
+      permitterData: "0x",
+    };
+
+    await nft
+      .connect(trader)
+      .setApprovalForAll(Ditto.Addresses.DittoPoolRouterRoyalties[chainId], true);
+    const order = new Ditto.Order(chainId, orderParams);
+    await sdkRouter.fillSellOrder(trader, order);
+
+    await nft.ownerOf(tokenId01).then((owner: any) => {
+      expect(owner).to.eq(dittoPool.address);
+    });
+  });
+});

--- a/packages/sdk/src/ditto/abis/DittoPool.json
+++ b/packages/sdk/src/ditto/abis/DittoPool.json
@@ -1,0 +1,1681 @@
+[
+  {
+    "inputs": [],
+    "name": "DittoPoolMainAlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidAdminFeeRecipient",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "basePrice",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainInvalidBasePrice",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "delta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainInvalidDelta",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidMsgSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidOwnerOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidPermitterData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainNoDirectNftTransfers",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeInvalidNftTokenId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeMustDepositLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeNotAuthorizedForLpId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeOneLpPerPrivatePool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeWrongPoolForLpId",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum CurveErrorCode",
+        "name": "error",
+        "type": "uint8"
+      }
+    ],
+    "name": "DittoPoolTradeBondingCurveError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInTooManyTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInsufficientBalanceToBuyNft",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInsufficientBalanceToPayFees",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInvalidTokenRecipient",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInvalidTokenSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNftAndCostDataLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNftAndLpIdsMustBeSameLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNftIdDoesNotMatchSwapData",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolTradeNftNotOwnedByPool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNoNftsProvided",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeOutTooFewTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "EnumerableMapNonexistentKey",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OwnerTwoStepNotOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OwnerTwoStepNotPendingOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAdminFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedAdminFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "adminFeeRecipient",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedAdminFeeRecipient",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBasePrice",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedBasePrice",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newDelta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedDelta",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newLpFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedLpFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "template",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "lpNft",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "permitter",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolMainPoolInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "referrer",
+        "type": "bytes"
+      }
+    ],
+    "name": "DittoPoolMarketMakeLiquidityAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "initialPositionTokenOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "referrer",
+        "type": "bytes"
+      }
+    ],
+    "name": "DittoPoolMarketMakeLiquidityCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "nftIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenWithdrawAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolMarketMakeLiquidityRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "buyerLpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "admin",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "protocol",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Fee",
+        "name": "fee",
+        "type": "tuple"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedNftForTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lpIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minExpectedTokenOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "nftSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "permitterData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct SwapNftsForTokensArgs",
+        "name": "args",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBasePrice",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newDelta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedNftsForTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "sellerLpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "admin",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "protocol",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Fee",
+        "name": "fee",
+        "type": "tuple"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedTokensForNft",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxExpectedTokenInput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nftRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct SwapTokensForNftsArgs",
+        "name": "args",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBasePrice",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newDelta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedTokensForNfts",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepOwnerRenouncedOwnership",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "currentOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPendingOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepOwnerStartedTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepOwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepPendingOwnerAcceptedTransfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "_privatePoolOwnerLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftIdList_",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenDepositAmount_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "permitterData_",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "referrer_",
+        "type": "bytes"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "adminFee",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "feeAdmin_",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "adminFeeRecipient",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "basePrice",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bondingCurve",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "curve",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "newFeeAdmin_",
+        "type": "uint96"
+      }
+    ],
+    "name": "changeAdminFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newAdminFeeRecipient_",
+        "type": "address"
+      }
+    ],
+    "name": "changeAdminFeeRecipient",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "newBasePrice_",
+        "type": "uint128"
+      }
+    ],
+    "name": "changeBasePrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "newDelta_",
+        "type": "uint128"
+      }
+    ],
+    "name": "changeDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "newFeeLp_",
+        "type": "uint96"
+      }
+    ],
+    "name": "changeLpFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "lpRecipient_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftIdList_",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenDepositAmount_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "permitterData_",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "referrer_",
+        "type": "bytes"
+      }
+    ],
+    "name": "createLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delta",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dittoPoolFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllLpIdTokenBalances",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lpId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenBalance",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LpIdToTokenBalance[]",
+        "name": "balances",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPoolHeldNftIds",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPoolLpIds",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "lpIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "numNfts_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "swapData_",
+        "type": "bytes"
+      }
+    ],
+    "name": "getBuyNftQuote",
+    "outputs": [
+      {
+        "internalType": "enum CurveErrorCode",
+        "name": "error",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newBasePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "specificNftId",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nftId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "lp",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "admin",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "protocol",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Fee",
+            "name": "fee",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct NftCostData[]",
+        "name": "nftCostData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLpIdForNftId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLpNft",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNftCountForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNftIdsForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "nftIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolTotalNftBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolTotalTokenBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalTokenBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "numNfts_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "swapData_",
+        "type": "bytes"
+      }
+    ],
+    "name": "getSellNftQuote",
+    "outputs": [
+      {
+        "internalType": "enum CurveErrorCode",
+        "name": "error",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newBasePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "specificNftId",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nftId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "lp",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "admin",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "protocol",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Fee",
+            "name": "fee",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct NftCostData[]",
+        "name": "nftCostData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTokenBalanceForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTotalBalanceForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nftBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isPrivatePool",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "templateIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nft",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "feeLp",
+            "type": "uint96"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "feeAdmin",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint128",
+            "name": "delta",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "basePrice",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "nftIdList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialTokenBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "templateInitData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "referrer",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PoolTemplate",
+        "name": "params_",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "template_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract LpNft",
+        "name": "lpNft_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPermitter",
+        "name": "permitter_",
+        "type": "address"
+      }
+    ],
+    "name": "initPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPrivatePool",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isPrivatePool_",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lpFee",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "feeLp_",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nft",
+    "outputs": [
+      {
+        "internalType": "contract IERC721",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "permitter",
+    "outputs": [
+      {
+        "internalType": "contract IPermitter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "feeProtocol_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "withdrawalAddress_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftIdList_",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenWithdrawAmount_",
+        "type": "uint256"
+      }
+    ],
+    "name": "pullLiquidity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lpIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minExpectedTokenOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "nftSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "permitterData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct SwapNftsForTokensArgs",
+        "name": "args_",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapNftsForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxExpectedTokenInput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nftRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct SwapTokensForNftsArgs",
+        "name": "args_",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapTokensForNfts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "template",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPendingOwner_",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk/src/ditto/abis/DittoPoolApp.json
+++ b/packages/sdk/src/ditto/abis/DittoPoolApp.json
@@ -1,0 +1,1805 @@
+[
+  {
+    "inputs": [],
+    "name": "DittoPoolAppInvalidTokenPrice",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolAppraisalIncorrectCollection",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolAppraisalIncorrectToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainAlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidAdminFeeRecipient",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "basePrice",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainInvalidBasePrice",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "delta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainInvalidDelta",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidMsgSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidOwnerOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainInvalidPermitterData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMainNoDirectNftTransfers",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeInvalidNftTokenId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeMustDepositLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeNotAuthorizedForLpId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeOneLpPerPrivatePool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolMarketMakeWrongPoolForLpId",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum CurveErrorCode",
+        "name": "error",
+        "type": "uint8"
+      }
+    ],
+    "name": "DittoPoolTradeBondingCurveError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInTooManyTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInsufficientBalanceToBuyNft",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInsufficientBalanceToPayFees",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInvalidTokenRecipient",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeInvalidTokenSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNftAndCostDataLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNftAndLpIdsMustBeSameLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNftIdDoesNotMatchSwapData",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolTradeNftNotOwnedByPool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeNoNftsProvided",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoPoolTradeOutTooFewTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "EnumerableMapNonexistentKey",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MathOverflowedMulDiv",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OwnerTwoStepNotOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OwnerTwoStepNotPendingOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "priceMaxBuy",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolAppUpdatePriceMaxBuy",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "priceMinSell",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolAppUpdatePriceMinSell",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oracle",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolAppraisalInitializedWithOracle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAdminFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedAdminFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "adminFeeRecipient",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedAdminFeeRecipient",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBasePrice",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedBasePrice",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newDelta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedDelta",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newLpFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolMainAdminChangedLpFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "template",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "lpNft",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "permitter",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolMainPoolInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "referrer",
+        "type": "bytes"
+      }
+    ],
+    "name": "DittoPoolMarketMakeLiquidityAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "initialPositionTokenOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "referrer",
+        "type": "bytes"
+      }
+    ],
+    "name": "DittoPoolMarketMakeLiquidityCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "nftIds",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenWithdrawAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoPoolMarketMakeLiquidityRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "buyerLpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "admin",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "protocol",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Fee",
+        "name": "fee",
+        "type": "tuple"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedNftForTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lpIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minExpectedTokenOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "nftSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "permitterData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct SwapNftsForTokensArgs",
+        "name": "args",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBasePrice",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newDelta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedNftsForTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "sellerLpId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "admin",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "protocol",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Fee",
+        "name": "fee",
+        "type": "tuple"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedTokensForNft",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxExpectedTokenInput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nftRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct SwapTokensForNftsArgs",
+        "name": "args",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBasePrice",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newDelta",
+        "type": "uint128"
+      }
+    ],
+    "name": "DittoPoolTradeSwappedTokensForNfts",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepOwnerRenouncedOwnership",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "currentOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPendingOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepOwnerStartedTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepOwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerTwoStepPendingOwnerAcceptedTransfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "_privatePoolOwnerLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftIdList_",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenDepositAmount_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "permitterData_",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "referrer_",
+        "type": "bytes"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "adminFee",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "feeAdmin_",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "adminFeeRecipient",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "basePrice",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bondingCurve",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "curve",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "newFeeAdmin_",
+        "type": "uint96"
+      }
+    ],
+    "name": "changeAdminFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newAdminFeeRecipient_",
+        "type": "address"
+      }
+    ],
+    "name": "changeAdminFeeRecipient",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "newBasePrice_",
+        "type": "uint128"
+      }
+    ],
+    "name": "changeBasePrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "newDelta_",
+        "type": "uint128"
+      }
+    ],
+    "name": "changeDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "newFeeLp_",
+        "type": "uint96"
+      }
+    ],
+    "name": "changeLpFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "priceMaxBuy_",
+        "type": "uint256"
+      }
+    ],
+    "name": "changePriceMaxBuy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "priceMinSell_",
+        "type": "uint256"
+      }
+    ],
+    "name": "changePriceMinSell",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "lpRecipient_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftIdList_",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenDepositAmount_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "permitterData_",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "referrer_",
+        "type": "bytes"
+      }
+    ],
+    "name": "createLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delta",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dittoPoolFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllLpIdTokenBalances",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lpId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenBalance",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LpIdToTokenBalance[]",
+        "name": "balances",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPoolHeldNftIds",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPoolLpIds",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "lpIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "getBuyNftQuote",
+    "outputs": [
+      {
+        "internalType": "enum CurveErrorCode",
+        "name": "error",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newBasePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "specificNftId",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nftId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "lp",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "admin",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "protocol",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Fee",
+            "name": "fee",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct NftCostData[]",
+        "name": "nftCostData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLpIdForNftId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLpNft",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNftCountForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNftIdsForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "nftIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolTotalNftBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolTotalTokenBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalTokenBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "getSellNftQuote",
+    "outputs": [
+      {
+        "internalType": "enum CurveErrorCode",
+        "name": "error",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newBasePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "specificNftId",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nftId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "lp",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "admin",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "protocol",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Fee",
+            "name": "fee",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct NftCostData[]",
+        "name": "nftCostData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTokenBalanceForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTotalBalanceForLpId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nftBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isPrivatePool",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "templateIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nft",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "feeLp",
+            "type": "uint96"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "feeAdmin",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint128",
+            "name": "delta",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "basePrice",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "nftIdList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "initialTokenBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "templateInitData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "referrer",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PoolTemplate",
+        "name": "params_",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "template_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract LpNft",
+        "name": "lpNft_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPermitter",
+        "name": "permitter_",
+        "type": "address"
+      }
+    ],
+    "name": "initPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPrivatePool",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isPrivatePool_",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lpFee",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "feeLp_",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nft",
+    "outputs": [
+      {
+        "internalType": "contract IERC721",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      {
+        "internalType": "contract IUpshotOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "permitter",
+    "outputs": [
+      {
+        "internalType": "contract IPermitter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceMaxBuy",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "priceMaxBuy_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceMinSell",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "priceMinSell_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "feeProtocol_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "withdrawalAddress_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftIdList_",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenWithdrawAmount_",
+        "type": "uint256"
+      }
+    ],
+    "name": "pullLiquidity",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lpIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minExpectedTokenOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "nftSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "permitterData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct SwapNftsForTokensArgs",
+        "name": "args_",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapNftsForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxExpectedTokenInput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenSender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nftRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct SwapTokensForNftsArgs",
+        "name": "args_",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapTokensForNfts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "template",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPendingOwner_",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk/src/ditto/abis/DittoPoolFactory.json
+++ b/packages/sdk/src/ditto/abis/DittoPoolFactory.json
@@ -1,0 +1,392 @@
+[
+  {
+    "inputs": [
+      { "internalType": "contract LpNft", "name": "lpNft_", "type": "address" },
+      { "internalType": "address", "name": "feeProtocolRecipient_", "type": "address" },
+      { "internalType": "uint96", "name": "feeProtocol_", "type": "uint96" },
+      { "internalType": "address[]", "name": "poolTemplates_", "type": "address[]" },
+      {
+        "internalType": "contract IPoolManager[]",
+        "name": "poolManagerTemplates_",
+        "type": "address[]"
+      },
+      {
+        "internalType": "contract IPermitter[]",
+        "name": "permitterTemplates_",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "DittoPoolFactoryInvalidProtocolFee", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "templateIndex", "type": "uint256" }],
+    "name": "DittoPoolFactoryInvalidTemplateIndex",
+    "type": "error"
+  },
+  { "inputs": [], "name": "ERC1167FailedCreateClone", "type": "error" },
+  { "inputs": [], "name": "OwnerTwoStepNotOwner", "type": "error" },
+  { "inputs": [], "name": "OwnerTwoStepNotPendingOwner", "type": "error" },
+  { "inputs": [], "name": "ReentrancyGuardReentrantCall", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "permitterTemplate",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolFactoryAdminAddedPermitterTemplate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "poolManagerTemplate",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolFactoryAdminAddedPoolManagerTemplate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "poolTemplate", "type": "address" }
+    ],
+    "name": "DittoPoolFactoryAdminAddedPoolTemplate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "router", "type": "address" }
+    ],
+    "name": "DittoPoolFactoryAdminAddedRouter",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "protocolFeeMultiplier",
+        "type": "uint96"
+      }
+    ],
+    "name": "DittoPoolFactoryAdminSetProtocolFeeMultiplier",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "protocolFeeRecipient",
+        "type": "address"
+      }
+    ],
+    "name": "DittoPoolFactoryAdminSetProtocolFeeRecipient",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "lpNft", "type": "address" }],
+    "name": "DittoPoolFactoryAdminUpdatedLpNft",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "bool", "name": "isPrivatePool", "type": "bool" },
+          { "internalType": "uint256", "name": "templateIndex", "type": "uint256" },
+          { "internalType": "address", "name": "token", "type": "address" },
+          { "internalType": "address", "name": "nft", "type": "address" },
+          { "internalType": "uint96", "name": "feeLp", "type": "uint96" },
+          { "internalType": "address", "name": "owner", "type": "address" },
+          { "internalType": "uint96", "name": "feeAdmin", "type": "uint96" },
+          { "internalType": "uint128", "name": "delta", "type": "uint128" },
+          { "internalType": "uint128", "name": "basePrice", "type": "uint128" },
+          { "internalType": "uint256[]", "name": "nftIdList", "type": "uint256[]" },
+          { "internalType": "uint256", "name": "initialTokenBalance", "type": "uint256" },
+          { "internalType": "bytes", "name": "templateInitData", "type": "bytes" },
+          { "internalType": "bytes", "name": "referrer", "type": "bytes" }
+        ],
+        "indexed": false,
+        "internalType": "struct PoolTemplate",
+        "name": "poolTemplate",
+        "type": "tuple"
+      },
+      { "indexed": false, "internalType": "address", "name": "dittoPool", "type": "address" },
+      {
+        "components": [
+          { "internalType": "uint256", "name": "templateIndex", "type": "uint256" },
+          { "internalType": "bytes", "name": "templateInitData", "type": "bytes" }
+        ],
+        "indexed": false,
+        "internalType": "struct PoolManagerTemplate",
+        "name": "poolManagerTemplate",
+        "type": "tuple"
+      },
+      { "indexed": false, "internalType": "address", "name": "poolManager", "type": "address" },
+      {
+        "components": [
+          { "internalType": "uint256", "name": "templateIndex", "type": "uint256" },
+          { "internalType": "bytes", "name": "templateInitData", "type": "bytes" },
+          { "internalType": "bytes", "name": "liquidityDepositPermissionData", "type": "bytes" }
+        ],
+        "indexed": false,
+        "internalType": "struct PermitterTemplate",
+        "name": "permitterTemplate",
+        "type": "tuple"
+      },
+      { "indexed": false, "internalType": "address", "name": "permitter", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "permitterInitData", "type": "bytes" }
+    ],
+    "name": "DittoPoolFactoryDittoPoolCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "previousOwner", "type": "address" }
+    ],
+    "name": "OwnerTwoStepOwnerRenouncedOwnership",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "currentOwner", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPendingOwner", "type": "address" }
+    ],
+    "name": "OwnerTwoStepOwnerStartedTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnerTwoStepOwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnerTwoStepPendingOwnerAcceptedTransfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IPermitter[]",
+        "name": "permitterTemplates_",
+        "type": "address[]"
+      }
+    ],
+    "name": "addPermitterTemplates",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IPoolManager[]",
+        "name": "poolManagerTemplates_",
+        "type": "address[]"
+      }
+    ],
+    "name": "addPoolManagerTemplates",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address[]", "name": "poolTemplates_", "type": "address[]" }],
+    "name": "addPoolTemplates",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "contract IDittoRouter[]", "name": "routers_", "type": "address[]" }
+    ],
+    "name": "addRouters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "bool", "name": "isPrivatePool", "type": "bool" },
+          { "internalType": "uint256", "name": "templateIndex", "type": "uint256" },
+          { "internalType": "address", "name": "token", "type": "address" },
+          { "internalType": "address", "name": "nft", "type": "address" },
+          { "internalType": "uint96", "name": "feeLp", "type": "uint96" },
+          { "internalType": "address", "name": "owner", "type": "address" },
+          { "internalType": "uint96", "name": "feeAdmin", "type": "uint96" },
+          { "internalType": "uint128", "name": "delta", "type": "uint128" },
+          { "internalType": "uint128", "name": "basePrice", "type": "uint128" },
+          { "internalType": "uint256[]", "name": "nftIdList", "type": "uint256[]" },
+          { "internalType": "uint256", "name": "initialTokenBalance", "type": "uint256" },
+          { "internalType": "bytes", "name": "templateInitData", "type": "bytes" },
+          { "internalType": "bytes", "name": "referrer", "type": "bytes" }
+        ],
+        "internalType": "struct PoolTemplate",
+        "name": "poolTemplate_",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "uint256", "name": "templateIndex", "type": "uint256" },
+          { "internalType": "bytes", "name": "templateInitData", "type": "bytes" }
+        ],
+        "internalType": "struct PoolManagerTemplate",
+        "name": "poolManagerTemplate_",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "uint256", "name": "templateIndex", "type": "uint256" },
+          { "internalType": "bytes", "name": "templateInitData", "type": "bytes" },
+          { "internalType": "bytes", "name": "liquidityDepositPermissionData", "type": "bytes" }
+        ],
+        "internalType": "struct PermitterTemplate",
+        "name": "permitterTemplate_",
+        "type": "tuple"
+      }
+    ],
+    "name": "createDittoPool",
+    "outputs": [
+      { "internalType": "contract IDittoPool", "name": "dittoPool", "type": "address" },
+      { "internalType": "uint256", "name": "lpId", "type": "uint256" },
+      { "internalType": "contract IPoolManager", "name": "poolManager", "type": "address" },
+      { "internalType": "contract IPermitter", "name": "permitter", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProtocolFee",
+    "outputs": [{ "internalType": "uint96", "name": "", "type": "uint96" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "router_", "type": "address" }],
+    "name": "isWhitelistedRouter",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lpNft",
+    "outputs": [{ "internalType": "contract LpNft", "name": "lpNft_", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "permitterTemplates",
+    "outputs": [{ "internalType": "contract IPermitter[]", "name": "", "type": "address[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolManagerTemplates",
+    "outputs": [{ "internalType": "contract IPoolManager[]", "name": "", "type": "address[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolTemplates",
+    "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFeeRecipient",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract LpNft", "name": "lpNft_", "type": "address" }],
+    "name": "setLpNft",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint96", "name": "feeProtocol_", "type": "uint96" }],
+    "name": "setProtocolFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "feeProtocolRecipient_", "type": "address" }],
+    "name": "setProtocolFeeRecipient",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newPendingOwner_", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk/src/ditto/abis/DittoRouterRoyalties.json
+++ b/packages/sdk/src/ditto/abis/DittoRouterRoyalties.json
@@ -1,0 +1,654 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract ILpNft",
+        "name": "lpNft_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "royaltyRegistry",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "DittoRouterDeadlinePassed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoRouterNotApprovedPool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoRouterOutputAmountTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoRoyaltyRouterNotImplemented",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoRoyaltyRouterOutputAmountTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DittoRoyaltyRouterRoyaltyExceedsSalePrice",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "issuer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "salePrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "royaltyAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DittoRouterRoyaltiesRoyaltyIssued",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "FETCH_TOKEN_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ROYALTY_REGISTRY",
+    "outputs": [
+      {
+        "internalType": "contract IRoyaltyRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftCollection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "salePrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "calculateRoyalties",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "royalties",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract ERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolTransferErc20From",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC721",
+        "name": "nft",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolTransferNftFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IDittoPool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lpIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes",
+            "name": "permitterData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct RobustNftInSwap[]",
+        "name": "swapList",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "robustSwapNftsForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IDittoPool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxCost",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct RobustSwap[]",
+        "name": "swapList",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "nftRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "robustSwapTokensForNfts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "remainingValue",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "contract IDittoPool",
+                "name": "pool",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "nftIds",
+                "type": "uint256[]"
+              },
+              {
+                "internalType": "uint256",
+                "name": "maxCost",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "swapData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct RobustSwap[]",
+            "name": "tokenToNftTrades",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "contract IDittoPool",
+                "name": "pool",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "nftIds",
+                "type": "uint256[]"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "lpIds",
+                "type": "uint256[]"
+              },
+              {
+                "internalType": "bytes",
+                "name": "permitterData",
+                "type": "bytes"
+              },
+              {
+                "internalType": "uint256",
+                "name": "minOutput",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "swapData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct RobustNftInSwap[]",
+            "name": "nftToTokenTrades",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "inputAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "tokenRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "nftRecipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct RobustComplexSwap",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "robustSwapTokensForNftsAndNftsForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "remainingValue",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      }
+    ],
+    "name": "supportsRoyalty",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "collectionSupportsRoyalty",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "contract IDittoPool",
+                "name": "pool",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "nftIds",
+                "type": "uint256[]"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "lpIds",
+                "type": "uint256[]"
+              },
+              {
+                "internalType": "bytes",
+                "name": "permitterData",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bytes",
+                "name": "swapData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct NftInSwap[]",
+            "name": "nftToTokenTrades",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "contract IDittoPool",
+                "name": "pool",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256[]",
+                "name": "nftIds",
+                "type": "uint256[]"
+              },
+              {
+                "internalType": "bytes",
+                "name": "swapData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct Swap[]",
+            "name": "tokenToNftTrades",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct ComplexSwap",
+        "name": "",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapNftsForSpecificNftsThroughTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IDittoPool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "lpIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes",
+            "name": "permitterData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct NftInSwap[]",
+        "name": "swapList",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minOutput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapNftsForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IDittoPool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "nftIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes",
+            "name": "swapData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Swap[]",
+        "name": "swapList",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "inputAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "nftRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTokensForNfts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "remainingValue",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk/src/ditto/abis/UpshotOracle.json
+++ b/packages/sdk/src/ditto/abis/UpshotOracle.json
@@ -1,0 +1,365 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "authenticator_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ECDSAInvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureLength",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureS",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UpshotOracleInvalidNonce",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UpshotOracleInvalidPriceTime",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UpshotOracleInvalidSigner",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "authenticator",
+        "type": "address"
+      }
+    ],
+    "name": "UpshotOracleAdminSetAuthenticator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "UpshotOracleAdminSetNonce",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "authenticator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "nft",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "timestamp",
+            "type": "uint96"
+          },
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "expiration",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nftId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "extraData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PriceData[]",
+        "name": "priceData",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "decodeTokenPrices",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "tokenPrices",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      }
+    ],
+    "name": "getNonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nonce_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "nft",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nftId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint96",
+        "name": "timestamp",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint96",
+        "name": "expiration",
+        "type": "uint96"
+      }
+    ],
+    "name": "getPriceMessage",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "authenticator_",
+        "type": "address"
+      }
+    ],
+    "name": "setAuthenticator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNonce",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/sdk/src/ditto/addresses.ts
+++ b/packages/sdk/src/ditto/addresses.ts
@@ -1,0 +1,36 @@
+import { ChainIdToAddress, Network } from "../utils";
+
+export const DittoPoolFactory: ChainIdToAddress = {
+  [Network.Ethereum]: "TBD",
+  [Network.EthereumGoerli]: "0xF316cfF1170e9f04e8EdB4f67D9D5BCdD84F142b",
+};
+
+export const LpNft: ChainIdToAddress = {
+  [Network.Ethereum]: "TBD",
+  [Network.EthereumGoerli]: "0x4881fA5995a6a811032d48Ca460fdA02626b4592",
+};
+
+export const DittoPoolRouter: ChainIdToAddress = {
+  [Network.Ethereum]: "TBD",
+  [Network.EthereumGoerli]: "0x7f04e2FA9a2E4f545d34F56aEf2c3DC3DCF9204b",
+};
+
+export const DittoPoolRouterRoyalties: ChainIdToAddress = {
+  [Network.Ethereum]: "TBD",
+  [Network.EthereumGoerli]: "0x24B1F548d90d393Eb6cA073dcE6cb90783Ed1d93",
+};
+
+export const Test721: ChainIdToAddress = {
+  [Network.Ethereum]: "0x0000000000000000000000000000000000000000",
+  [Network.EthereumGoerli]: "0x0133B5f5601D0B2980ac812A1719760ba3ea53e7",
+};
+
+export const Test20: ChainIdToAddress = {
+  [Network.Ethereum]: "0x0000000000000000000000000000000000000000",
+  [Network.EthereumGoerli]: "0x8cAa8de40048C4c840014BdEc44373548b61568d",
+};
+
+export const UpshotOracle: ChainIdToAddress = {
+  [Network.Ethereum]: "0x0000000000000000000000000000000000000000",
+  [Network.EthereumGoerli]: "0x6c9808CB1Fb906f34D9Ab96B7B58eF91a67062b5",
+};

--- a/packages/sdk/src/ditto/index.ts
+++ b/packages/sdk/src/ditto/index.ts
@@ -1,0 +1,6 @@
+import * as Addresses from "./addresses";
+import { Router } from "./router";
+import { Order } from "./order";
+import { OrderParams } from "./types";
+
+export { Addresses, Router, Order, OrderParams };

--- a/packages/sdk/src/ditto/order.ts
+++ b/packages/sdk/src/ditto/order.ts
@@ -1,0 +1,33 @@
+import * as Types from "./types";
+import { lc, s, bn } from "../utils";
+
+export class Order {
+  public chainId: number;
+  public params: Types.OrderParams;
+
+  constructor(chainId: number, params: Types.OrderParams) {
+    this.chainId = chainId;
+
+    try {
+      this.params = normalize(params);
+    } catch {
+      throw new Error("Invalid params");
+    }
+  }
+}
+
+const normalize = (order: Types.OrderParams): Types.OrderParams => {
+  // Perform some normalization operations on the order:
+  // - convert bignumbers to strings where needed
+  // - convert strings to numbers where needed
+  // - lowercase all strings
+  return {
+    pool: lc(s(order.pool)),
+    nftIds: order.nftIds.map(bn),
+    lpIds: order.lpIds ? order.lpIds.map(bn) : undefined,
+    expectedTokenAmount: bn(order.expectedTokenAmount),
+    recipient: lc(s(order.recipient)),
+    swapData: lc(s(order.swapData)),
+    permitterData: lc(s(order.permitterData)),
+  };
+};

--- a/packages/sdk/src/ditto/router.ts
+++ b/packages/sdk/src/ditto/router.ts
@@ -1,0 +1,91 @@
+import { Signer } from "@ethersproject/abstract-signer";
+import { Contract, ContractTransaction } from "@ethersproject/contracts";
+
+import * as Addresses from "./addresses";
+import { Order } from "./order";
+import { bn, TxData } from "../utils";
+import { NftInSwapStruct, SwapStruct } from "./types";
+
+import RouterAbi from "./abis/DittoRouterRoyalties.json";
+
+const tenMinutesFromNow = () => bn(Math.floor(Date.now() / 1000) + 10 * 60);
+
+export class Router {
+  public chainId: number;
+  public contract: Contract;
+
+  constructor(chainId: number) {
+    this.chainId = chainId;
+    this.contract = new Contract(Addresses.DittoPoolRouterRoyalties[this.chainId], RouterAbi);
+  }
+
+  // --- TRADING ERC20 TOKENS FOR NFTs
+
+  public async fillBuyOrder(taker: Signer, order: Order): Promise<ContractTransaction> {
+    const tx = this.fillBuyOrderTx(await taker.getAddress(), order);
+    return taker.sendTransaction(tx);
+  }
+
+  public fillBuyOrderTx(
+    taker: string,
+    order: Order,
+    options?: {
+      recipient?: string;
+    }
+  ): TxData {
+    const swap: SwapStruct = {
+      pool: order.params.pool,
+      nftIds: order.params.nftIds.map((id) => bn(id)),
+      swapData: order.params.swapData,
+    };
+    const swapTokensForNftsParams = [
+      [swap],
+      order.params.expectedTokenAmount,
+      options?.recipient ?? order.params.recipient ?? taker,
+      tenMinutesFromNow(),
+    ];
+    const functionFragment = this.contract.interface.getFunction("swapTokensForNfts");
+    return {
+      from: taker,
+      to: this.contract.address,
+      data: this.contract.interface.encodeFunctionData(functionFragment, swapTokensForNftsParams),
+    };
+  }
+
+  public async fillSellOrder(taker: Signer, order: Order): Promise<ContractTransaction> {
+    const tx = this.fillSellOrderTx(await taker.getAddress(), order);
+    return taker.sendTransaction(tx);
+  }
+
+  // --- TRADING NFTs FOR ERC20 TOKENS
+
+  public fillSellOrderTx(
+    taker: string,
+    order: Order,
+    options?: {
+      recipient?: string;
+    }
+  ): TxData {
+    const swap: NftInSwapStruct = {
+      pool: order.params.pool,
+      nftIds: order.params.nftIds.map((id) => bn(id)),
+      lpIds: order.params.lpIds!.map((id) => bn(id)),
+      permitterData: order.params.permitterData!,
+      swapData: order.params.swapData,
+    };
+    const swapNftsForTokensParams = [
+      [swap],
+      order.params.expectedTokenAmount,
+      options?.recipient ?? order.params.recipient ?? taker,
+      tenMinutesFromNow(),
+    ];
+    return {
+      from: taker,
+      to: this.contract.address,
+      data: this.contract.interface.encodeFunctionData(
+        "swapNftsForTokens",
+        swapNftsForTokensParams
+      ),
+    };
+  }
+}

--- a/packages/sdk/src/ditto/types.ts
+++ b/packages/sdk/src/ditto/types.ts
@@ -1,0 +1,25 @@
+import { BigNumberish, BytesLike } from "ethers";
+
+export type OrderParams = {
+  pool: string;
+  nftIds: BigNumberish[];
+  lpIds?: BigNumberish[];
+  expectedTokenAmount: BigNumberish; // buy = erc20 inputAmount, sell = minOutput erc20 amount
+  recipient?: string; // buy = nftRecipient, sell = erc20 tokenRecipient
+  swapData: BytesLike; // defaults to 0x0 (of type bytes)
+  permitterData?: BytesLike; // only required for selling
+};
+
+export type SwapStruct = {
+  pool: string;
+  nftIds: BigNumberish[];
+  swapData: BytesLike;
+};
+
+export type NftInSwapStruct = {
+  pool: string;
+  nftIds: BigNumberish[];
+  lpIds: BigNumberish[];
+  permitterData: BytesLike;
+  swapData: BytesLike;
+};

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,7 @@ import * as CryptoKitties from "./cryptokitties";
 import * as CryptoPunks from "./cryptopunks";
 import * as CryptoVoxels from "./cryptovoxels";
 import * as Decentraland from "./decentraland";
+import * as Ditto from "./ditto";
 import * as Element from "./element";
 import * as Foundation from "./foundation";
 import * as LooksRare from "./looks-rare";
@@ -87,6 +88,7 @@ export {
   CryptoPunks,
   CryptoVoxels,
   Decentraland,
+  Ditto,
   Element,
   Foundation,
   LooksRare,


### PR DESCRIPTION
Hi folks,

We have decided to parse the changes required to add dittohq.xyz integration to reservoir in two smaller more manageable and reviewable PRs: one which does the on-chain settlement layer (the router module to trade with Ditto + sdk support for settlement) and one which adds the indexer support.

Right now the indexer efforts are focused on #5121 (CC: @KjetilVaa). This PR is for the settlement layer component as well as javascript support for trading on Ditto via the reservoir sdk.

This PR adds DittoModule.sol for the reservoir router module to trade with Ditto, tests for that functionality under `packages/contracts/test/router/ditto` and then adds an sdk module under `packages/sdk/src/ditto` with tests for the sdk module under `packages/contracts/test/sdk/ditto`

1. I wasn't sure if  `packages/contracts/test/sdk/ditto` was the right place to test sdk support, and if my contributions to the sdk are functional so that e.g. users of ReservoirKit UI can settle trades on Ditto now using the code in the `packages/sdk/src/ditto` folder. Are there further unit tests that need to be written to test the full end-to-end flow against Ditto?
2. We based our reservoir integration code off of sudoswap v1, which appears to not use a reservoir module but instead [route transactions through sudoswap's royalty router directly](https://github.com/reservoirprotocol/indexer/blob/8833a9f21c7fdd97fb96ef2cedab44afca286c3b/packages/sdk/src/sudoswap/router.ts#L20) bypassing the reservoir smart contracts. Is that correct? Shouldn't the reservoir sdk use the reservoir router smart contracts for execution? Should this PR changed so that the reservoir sdk uses the reservoir router ditto module instead?

Other than those two questions, please advise if there are any additional tasks required to get this PR merged into reservoir's codebase.

Thanks!
