### PR TITLE
fix: deprecate v1 top selling collections

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/get-top-selling-collections/v1.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-top-selling-collections/v1.ts
@@ -23,10 +23,10 @@ export const getTopSellingCollectionsV1Options: RouteOptions = {
   },
   description: "Top Selling Collections",
   notes: "Get top selling and minting collections",
-  tags: ["api", "Collections"],
+  tags: ["api", "x-deprecated"],
   plugins: {
     "hapi-swagger": {
-      order: 3,
+      deprecated: true,
     },
   },
   validate: {


### PR DESCRIPTION
Added tag: "x-deprecated"
Set: "hapi-swagger": {deprecated: true,}