### PR TITLE
[DIT-693] dittohq.xyz eth->weth trading test support, DittoModule separate token sender from token recipients can be different actors

### DIFF
--- a/packages/contracts/test/router/ditto/weth-trades.test.ts
+++ b/packages/contracts/test/router/ditto/weth-trades.test.ts
@@ -1,0 +1,285 @@
+import { BigNumber } from "@ethersproject/bignumber";
+import { Contract, ContractReceipt } from "@ethersproject/contracts";
+import { parseEther } from "@ethersproject/units";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { getDittoContracts } from "../helpers/ditto";
+import { getChainId, reset } from "../../utils";
+
+import DittoPoolAbi from "@reservoir0x/sdk/src/ditto/abis/DittoPool.json";
+import { generateSwapInfo } from "@reservoir0x/sdk/src/router/v6/swap";
+import * as Sdk from "@reservoir0x/sdk/src";
+
+describe("DittoModule", () => {
+  let chainId: number;
+  let poolAddress: string;
+  let initialTokenBalance: BigNumber;
+  let deployer: SignerWithAddress;
+  let marketMaker: SignerWithAddress;
+  let trader: SignerWithAddress;
+  let marketMakerLpId: BigNumber;
+
+  let nft: Contract;
+  let dittoPool: Contract;
+  let dittoPoolFactory: Contract;
+
+  let router: Contract;
+  let dittoModule: Contract;
+  let weth: Contract;
+  let swapModule: Contract;
+
+  // Random numbers that aren't likely to already have been minted
+  const tokenId00 = ethers.BigNumber.from("0x13376969420123");
+  const tokenId01 = ethers.BigNumber.from("0x13376969420124");
+
+  beforeEach(async () => {
+    chainId = getChainId();
+    ({ nft, dittoPoolFactory, weth } = getDittoContracts());
+    // signers start off with 10,000 ETH
+    [deployer, marketMaker, trader] = await ethers.getSigners();
+    initialTokenBalance = parseEther("100");
+
+    router = await ethers
+      .getContractFactory("ReservoirV6_0_1", deployer)
+      .then((factory) => factory.deploy());
+    dittoModule = await ethers
+      .getContractFactory("DittoModule", deployer)
+      .then((factory) => factory.deploy(deployer.address, router.address));
+    swapModule = await ethers
+      .getContractFactory("SwapModule", deployer)
+      .then((factory) =>
+        factory.deploy(deployer.address, router.address, weth.address, ethers.constants.AddressZero)
+      );
+
+    const ownerAddress: string = await dittoPoolFactory.owner();
+    const ownerSigner: SignerWithAddress = await ethers.getImpersonatedSigner(ownerAddress);
+    await dittoPoolFactory.connect(ownerSigner).addRouters([dittoModule.address]);
+
+    await nft.connect(marketMaker).mint(marketMaker.address, tokenId00);
+    await nft.connect(marketMaker).mint(marketMaker.address, tokenId01);
+    await nft.connect(marketMaker).setApprovalForAll(dittoPoolFactory.address, true);
+    const deposit = await weth.connect(marketMaker).deposit({ value: initialTokenBalance });
+    await deposit.wait();
+    await weth.connect(marketMaker).approve(dittoPoolFactory.address, ethers.constants.MaxUint256);
+
+    // Create a pool to trade with, with the NFTs deposited into the pool
+
+    const poolTemplate = {
+      isPrivatePool: false,
+      templateIndex: 3, // LINEAR
+      token: weth.address,
+      nft: nft.address,
+      feeLp: 0,
+      owner: marketMaker.address,
+      feeAdmin: 0,
+      delta: ethers.utils.parseEther("1.01"),
+      basePrice: ethers.utils.parseEther("3"),
+      nftIdList: [tokenId00, tokenId01],
+      initialTokenBalance: initialTokenBalance,
+      templateInitData: "0x",
+      referrer: "0x",
+    };
+    const poolManagerTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+    };
+    const permitterTemplate = {
+      templateIndex: ethers.constants.MaxUint256,
+      templateInitData: "0x",
+      liquidityDepositPermissionData: "0x",
+    };
+    const creation = await dittoPoolFactory
+      .connect(marketMaker)
+      .createDittoPool(poolTemplate, poolManagerTemplate, permitterTemplate);
+    const result: ContractReceipt = await creation.wait();
+    result.events!.forEach((event) => {
+      if (event.event === "DittoPoolFactoryDittoPoolCreated") {
+        poolAddress = event.args!.dittoPool;
+      }
+    });
+    const dittoPoolInterface = new ethers.utils.Interface(DittoPoolAbi);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    result.logs.forEach((log: any) => {
+      try {
+        const event = dittoPoolInterface.parseLog(log);
+        if (event.name === "DittoPoolMarketMakeLiquidityCreated") {
+          marketMakerLpId = event.args!.lpId;
+        }
+      } catch (e) {
+        return;
+      }
+    });
+    dittoPool = new ethers.Contract(poolAddress, DittoPoolAbi, trader);
+  });
+
+  afterEach(reset);
+
+  it("Purchase an NFT with unwrapped native ether", async () => {
+    await weth.balanceOf(trader.address).then((balance: BigNumber) => {
+      expect(balance).to.equal(ethers.constants.Zero);
+    });
+
+    const wrapInfo = await generateSwapInfo(
+      chainId,
+      ethers.getDefaultProvider(),
+      "",
+      Sdk.Common.Addresses.Native[chainId],
+      weth.address,
+      initialTokenBalance,
+      {
+        module: swapModule,
+        transfers: [
+          {
+            toETH: false,
+            recipient: trader.address,
+            amount: initialTokenBalance,
+          },
+        ],
+        refundTo: trader.address,
+        revertIfIncomplete: true,
+      }
+    );
+
+    const approve = await weth.connect(trader).approve(dittoModule.address, initialTokenBalance);
+    await approve.wait();
+
+    // Fetch the current price
+    const result = await dittoPool.getBuyNftQuote(2, "0x");
+    const inputValue = result[3];
+
+    const fillTo: string = trader.address;
+    const refundTo: string = trader.address;
+    const revertIfIncomplete = false;
+    const amountPayment: BigNumber = inputValue;
+
+    const eRC20ListingParams = [fillTo, refundTo, revertIfIncomplete, weth.address, amountPayment];
+
+    const recipient: string = dittoPool.address;
+    const amountFee: BigNumber = parseEther("0");
+
+    const fee = [recipient, amountFee];
+
+    const orderParams = [[tokenId00, tokenId01], "0x"];
+
+    const buyWithERC20 = [[dittoPool.address], [orderParams], eRC20ListingParams, [fee]];
+
+    const data = dittoModule.interface.encodeFunctionData("buyWithERC20", buyWithERC20);
+    const executions = [dittoModule.address, data, 0];
+    await router
+      .connect(trader)
+      .execute([wrapInfo.execution, executions], { value: initialTokenBalance });
+
+    await nft.ownerOf(tokenId00).then((owner: string) => {
+      expect(owner).to.eq(fillTo);
+    });
+    await nft.ownerOf(tokenId01).then((owner: string) => {
+      expect(owner).to.eq(fillTo);
+    });
+    await weth.balanceOf(trader.address).then((balance: BigNumber) => {
+      expect(balance).to.equal(initialTokenBalance.sub(amountPayment));
+    });
+  });
+
+  it("Sell an NFT for native unwrapped ether", async () => {
+    await weth.balanceOf(trader.address).then((balance: BigNumber) => {
+      expect(balance).to.equal(ethers.constants.Zero);
+    });
+    await trader.getBalance().then((balance: BigNumber) => {
+      expect(balance).to.equal(parseEther("10000"));
+    });
+    await weth.balanceOf(dittoPool.address).then((balance: BigNumber) => {
+      expect(balance).to.equal(initialTokenBalance);
+    });
+    const tokenId03 = 130019123456789; // probably not minted yet
+    await nft.connect(trader).mint(trader.address, tokenId03);
+    await nft.ownerOf(tokenId03).then((owner: string) => {
+      expect(owner).to.eq(trader.address);
+    });
+    await nft.connect(trader).setApprovalForAll(dittoModule.address, true);
+
+    const sellQuote = await dittoPool.getSellNftQuote(1, "0x");
+    const outputValue = sellQuote[3];
+
+    const fee = [poolAddress, 0];
+
+    const orderParams = {
+      nftIds: [tokenId03],
+      swapData: "0x",
+    };
+
+    const offerParams = {
+      fillTo: trader.address,
+      refundTo: trader.address,
+      revertIfIncomplete: false,
+    };
+
+    const sell = [
+      poolAddress,
+      orderParams,
+      [marketMakerLpId.toString()],
+      "0x",
+      outputValue,
+      offerParams,
+      [fee],
+    ];
+
+    const data = dittoModule.interface.encodeFunctionData("sell", sell);
+    const swapExecution = [dittoModule.address, data, 0];
+
+    await weth.connect(trader).approve(swapModule.address, outputValue);
+    await weth.connect(trader).approve(router.address, outputValue);
+    await weth.connect(trader).approve(dittoModule.address, outputValue);
+
+    const unWrapInfo = await generateSwapInfo(
+      chainId,
+      ethers.getDefaultProvider(),
+      "",
+      weth.address,
+      Sdk.Common.Addresses.Native[chainId],
+      outputValue,
+      {
+        module: swapModule,
+        transfers: [
+          {
+            toETH: false,
+            recipient: trader.address,
+            amount: outputValue,
+          },
+        ],
+        refundTo: trader.address,
+        revertIfIncomplete: false,
+      }
+    );
+
+    // the unwrap function on the swapModule only works if the swap module
+    // holds the weth itself. But the DittoModule (right now) won't let you
+    // send the weth to another address other than the trader
+    // so we have to send the swapModule the weth so that it can then unwrap it
+    // and send it back
+    const transferFromDetail = weth.interface.getFunction(
+      "transferFrom(address, address, uint256)"
+    );
+    const transferFromData = weth.interface.encodeFunctionData(transferFromDetail, [
+      trader.address,
+      swapModule.address,
+      outputValue,
+    ]);
+    const transferFromExecution = [weth.address, transferFromData, 0];
+
+    const traderBalanceBeforeTrade = await trader.getBalance();
+    const executionPath = [swapExecution, transferFromExecution, unWrapInfo.execution];
+    const routerExecution = await router.connect(trader).execute(executionPath);
+    const routerExecutionReceipt = await routerExecution.wait();
+    const routerExecutionGasUsed = routerExecutionReceipt.gasUsed;
+    const routerExecutionGasPrice = routerExecutionReceipt.effectiveGasPrice;
+    const routerExecutionGasCost = routerExecutionGasUsed.mul(routerExecutionGasPrice);
+
+    await trader.getBalance().then((balance: BigNumber) => {
+      expect(balance).to.equal(
+        ethers.BigNumber.from(traderBalanceBeforeTrade).add(outputValue).sub(routerExecutionGasCost)
+      );
+    });
+  });
+});

--- a/packages/contracts/test/router/ditto/weth-trades.test.ts
+++ b/packages/contracts/test/router/ditto/weth-trades.test.ts
@@ -228,9 +228,7 @@ describe("DittoModule", () => {
     const data = dittoModule.interface.encodeFunctionData("sell", sell);
     const swapExecution = [dittoModule.address, data, 0];
 
-    await weth.connect(trader).approve(swapModule.address, outputValue);
     await weth.connect(trader).approve(router.address, outputValue);
-    await weth.connect(trader).approve(dittoModule.address, outputValue);
 
     const unWrapInfo = await generateSwapInfo(
       chainId,
@@ -243,7 +241,7 @@ describe("DittoModule", () => {
         module: swapModule,
         transfers: [
           {
-            toETH: false,
+            toETH: true,
             recipient: trader.address,
             amount: outputValue,
           },

--- a/packages/contracts/test/router/helpers/ditto.ts
+++ b/packages/contracts/test/router/helpers/ditto.ts
@@ -7,6 +7,7 @@ import * as Sdk from "@reservoir0x/sdk/src";
 import Erc20Abi from "@reservoir0x/sdk/src/common/abis/Erc20.json";
 import Erc721Abi from "@reservoir0x/sdk/src/common/abis/Erc721.json";
 import DittoPoolFactoryAbi from "@reservoir0x/sdk/src/ditto/abis/DittoPoolFactory.json";
+import WethAbi from "@reservoir0x/sdk/src/ditto/abis/Weth.json";
 
 export const getDittoContracts = () => {
   const chainId = getChainId();
@@ -14,30 +15,31 @@ export const getDittoContracts = () => {
   const testNftAddress = ethers.utils.getAddress(Sdk.Ditto.Addresses.Test721[chainId]);
   const nft = new Contract(testNftAddress, Erc721Abi, ethers.provider);
 
-  const mintStanza = {
-    inputs: [
-      {
-        internalType: "address",
-        name: "to",
-        type: "address",
-      },
-      {
-        internalType: "uint256",
-        name: "idOrAmount",
-        type: "uint256",
-      },
-    ],
-    name: "mint",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  };
+  const mintStanza = [
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "to",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "idOrAmount",
+          type: "uint256",
+        },
+      ],
+      name: "mint",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+  ];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Erc20Abi.push(mintStanza as any);
+  const mintableTokenAbi = [...Erc20Abi, ...mintStanza];
 
   const testTokenAddress = ethers.utils.getAddress(Sdk.Ditto.Addresses.Test20[chainId]);
-  const token: Contract = new Contract(testTokenAddress, Erc20Abi, ethers.provider);
+  const token: Contract = new Contract(testTokenAddress, mintableTokenAbi, ethers.provider);
 
   const dittoPoolFactoryAddress = ethers.utils.getAddress(
     Sdk.Ditto.Addresses.DittoPoolFactory[chainId]
@@ -48,5 +50,11 @@ export const getDittoContracts = () => {
     ethers.provider
   );
 
-  return { nft, token, dittoPoolFactory };
+  const weth: Contract = new Contract(
+    Sdk.Common.Addresses.WNative[chainId],
+    WethAbi,
+    ethers.provider
+  );
+
+  return { nft, token, dittoPoolFactory, weth };
 };

--- a/packages/sdk/src/ditto/abis/Weth.json
+++ b/packages/sdk/src/ditto/abis/Weth.json
@@ -1,0 +1,153 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "guy", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "src", "type": "address" },
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "address" },
+      { "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "guy", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/packages/sdk/src/router/v6/abis/DittoModule.json
+++ b/packages/sdk/src/router/v6/abis/DittoModule.json
@@ -99,6 +99,11 @@
       {
         "components": [
           {
+            "internalType": "address",
+            "name": "tokenSender",
+            "type": "address"
+          },
+          {
             "internalType": "uint256[]",
             "name": "nftIds",
             "type": "uint256[]"
@@ -227,7 +232,7 @@
   {
     "inputs": [
       {
-        "internalType": "contract ERC20",
+        "internalType": "contract IERC20",
         "name": "token",
         "type": "address"
       },
@@ -302,6 +307,11 @@
       },
       {
         "components": [
+          {
+            "internalType": "address",
+            "name": "tokenSender",
+            "type": "address"
+          },
           {
             "internalType": "uint256[]",
             "name": "nftIds",

--- a/packages/sdk/src/router/v6/addresses.ts
+++ b/packages/sdk/src/router/v6/addresses.ts
@@ -99,7 +99,7 @@ export const CollectionXyzModule: ChainIdToAddress = {
 };
 
 export const DittoModule: ChainIdToAddress = {
-  [Network.EthereumGoerli]: "0xcc97a1297c78d5860a4ceabc8fe6218601b1f42c",
+  [Network.EthereumGoerli]: "0x1090afe10281912678a05d89fabd5fbe77d7f97f",
 };
 
 export const FoundationModule: ChainIdToAddress = {


### PR DESCRIPTION
Adds a unit test demonstrating wrapping and unwrapping ether while simultaneously trading in one transaction with dittohq.xyz pools

Edit: As a result of reviewer comments this PR now does more:

Also changes DittoModule.sol to support independent tokenSenders from tokenRecipients (this is a feature we have always supported on our own routers, but not originally on the reservoir router module). This allows for example, a tokenSender that is the WETH SwapModule to send wrapped ether on behalf of someone that called it in the first execution, and have the NFTs resulting from that trade sent to the EOA that initiated the trade directly