### PR TITLE
feat: clarify displayCurrency on some endpoint

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/get-collections/v7.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-collections/v7.ts
@@ -142,7 +142,7 @@ export const getCollectionsV7Options: RouteOptions = {
       displayCurrency: Joi.string()
         .lowercase()
         .pattern(regex.address)
-        .description("Input any ERC20 address to return result in given currency"),
+        .description("Input any ERC20 address to return result in given currency. Applies to `topBid` and `floorAsk`."),
     }).oxor("id", "slug", "name", "collectionsSetId", "community", "contract"),
   },
   response: {

--- a/packages/indexer/src/api/endpoints/collections/get-user-collections/v3.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-user-collections/v3.ts
@@ -70,7 +70,7 @@ export const getUserCollectionsV3Options: RouteOptions = {
       displayCurrency: Joi.string()
         .lowercase()
         .pattern(regex.address)
-        .description("Input any ERC20 address to return result in given currency."),
+        .description("Input any ERC20 address to return result in given currency. Applies to `topBid` and `floorAsk`."),
     }),
   },
   response: {

--- a/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-tokens/v6.ts
@@ -198,7 +198,7 @@ export const getTokensV6Options: RouteOptions = {
       displayCurrency: Joi.string()
         .lowercase()
         .pattern(regex.address)
-        .description("Input any ERC20 address to return result in given currency"),
+        .description("Input any ERC20 address to return result in given currency. Applies to `topBid` and `floorAsk`."),
     })
       .or("collection", "contract", "tokens", "tokenSetId", "community", "collectionsSetId")
       .oxor("collection", "contract", "tokens", "tokenSetId", "community", "collectionsSetId")

--- a/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v7.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v7.ts
@@ -130,7 +130,7 @@ export const getUserTokensV7Options: RouteOptions = {
       displayCurrency: Joi.string()
         .lowercase()
         .pattern(regex.address)
-        .description("Input any ERC20 address to return result in given currency"),
+        .description("Input any ERC20 address to return result in given currency. Applies to `topBid` and `floorAsk`."),
     }),
   },
   response: {


### PR DESCRIPTION
Added clarification that displayCurrency changes the topBid and floorAsk amounts only for some endpoint.