### PR TITLE
feat: filter out wash trading and fix percent change

### DIFF
--- a/packages/indexer/src/elasticsearch/indexes/activities/index.ts
+++ b/packages/indexer/src/elasticsearch/indexes/activities/index.ts
@@ -356,6 +356,27 @@ export const getRecentSalesByCollection = async (
           },
         },
         {
+          bool: {
+            should: [
+              {
+                term: {
+                  "event.washTradingScore": 0,
+                },
+              },
+              {
+                bool: {
+                  must_not: {
+                    exists: {
+                      field: "event.washTradingScore",
+                    },
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+        {
           terms: {
             type: fillType == "any" ? ["sale", "mint"] : [fillType],
           },
@@ -454,6 +475,27 @@ const getPastResults = async (
           },
         },
         {
+          bool: {
+            should: [
+              {
+                term: {
+                  "event.washTradingScore": 0,
+                },
+              },
+              {
+                bool: {
+                  must_not: {
+                    exists: {
+                      field: "event.washTradingScore",
+                    },
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        },
+        {
           range: {
             timestamp: {
               gte: previousPeriodStartTime,
@@ -470,6 +512,7 @@ const getPastResults = async (
     collections: {
       terms: {
         field: "collection.id",
+        size: collections.length,
       },
       aggs: {
         total_sales: {
@@ -523,6 +566,27 @@ export const getTopSellingCollectionsV2 = async (params: {
         {
           terms: {
             type: fillType == "any" ? ["sale", "mint"] : [fillType],
+          },
+        },
+        {
+          bool: {
+            should: [
+              {
+                term: {
+                  "event.washTradingScore": 0,
+                },
+              },
+              {
+                bool: {
+                  must_not: {
+                    exists: {
+                      field: "event.washTradingScore",
+                    },
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
           },
         },
         {

--- a/packages/indexer/src/elasticsearch/indexes/activities/index.ts
+++ b/packages/indexer/src/elasticsearch/indexes/activities/index.ts
@@ -356,32 +356,17 @@ export const getRecentSalesByCollection = async (
           },
         },
         {
-          bool: {
-            should: [
-              {
-                term: {
-                  "event.washTradingScore": 0,
-                },
-              },
-              {
-                bool: {
-                  must_not: {
-                    exists: {
-                      field: "event.washTradingScore",
-                    },
-                  },
-                },
-              },
-            ],
-            minimum_should_match: 1,
-          },
-        },
-        {
           terms: {
             type: fillType == "any" ? ["sale", "mint"] : [fillType],
           },
         },
       ],
+
+      must_not: {
+        term: {
+          "event.washTradingScore": 1,
+        },
+      },
     },
   } as any;
 
@@ -475,27 +460,6 @@ const getPastResults = async (
           },
         },
         {
-          bool: {
-            should: [
-              {
-                term: {
-                  "event.washTradingScore": 0,
-                },
-              },
-              {
-                bool: {
-                  must_not: {
-                    exists: {
-                      field: "event.washTradingScore",
-                    },
-                  },
-                },
-              },
-            ],
-            minimum_should_match: 1,
-          },
-        },
-        {
           range: {
             timestamp: {
               gte: previousPeriodStartTime,
@@ -505,6 +469,12 @@ const getPastResults = async (
           },
         },
       ],
+
+      must_not: {
+        term: {
+          "event.washTradingScore": 1,
+        },
+      },
     },
   } as any;
 
@@ -568,27 +538,7 @@ export const getTopSellingCollectionsV2 = async (params: {
             type: fillType == "any" ? ["sale", "mint"] : [fillType],
           },
         },
-        {
-          bool: {
-            should: [
-              {
-                term: {
-                  "event.washTradingScore": 0,
-                },
-              },
-              {
-                bool: {
-                  must_not: {
-                    exists: {
-                      field: "event.washTradingScore",
-                    },
-                  },
-                },
-              },
-            ],
-            minimum_should_match: 1,
-          },
-        },
+
         {
           range: {
             timestamp: {
@@ -598,15 +548,21 @@ export const getTopSellingCollectionsV2 = async (params: {
           },
         },
       ],
-      ...(trendingExcludedContracts && {
-        must_not: [
+
+      must_not: [
+        {
+          term: {
+            "event.washTradingScore": 1,
+          },
+        },
+        ...(trendingExcludedContracts && [
           {
             terms: {
               "collection.id": excludedCollections,
             },
           },
-        ],
-      }),
+        ]),
+      ],
     },
   } as any;
 


### PR DESCRIPTION
- adding a filter to remove wash trading sales
- added size to aggregation to avoid limiting to 10 by default