### PR TITLE
feat: support more unconvered extensions for manifold

### DIFF
--- a/packages/indexer/src/orderbook/mints/calldata/detector/manifold.ts
+++ b/packages/indexer/src/orderbook/mints/calldata/detector/manifold.ts
@@ -456,38 +456,9 @@ export const extractByCollectionERC1155 = async (
             details: {
               tx: {
                 to: extension.toLowerCase(),
-                data: {
-                  // `mint`
-                  signature: "0xfa2b068f",
-                  params: [
-                    {
-                      kind: "contract",
-                      abiType: "address",
-                    },
-                    {
-                      kind: "unknown",
-                      abiType: "uint256",
-                      abiValue: instanceId,
-                    },
-                    {
-                      kind: "unknown",
-                      abiType: "uint32",
-                      abiValue: 0,
-                    },
-                    {
-                      kind: "unknown",
-                      abiType: "bytes32[]",
-                      abiValue: [],
-                    },
-                    {
-                      kind: "recipient",
-                      abiType: "address",
-                    },
-                  ],
-                },
                 // data: {
-                //   // `mintBatch`
-                //   signature: "0x26c858a4",
+                //   // `mint`
+                //   signature: "0xfa2b068f",
                 //   params: [
                 //     {
                 //       kind: "contract",
@@ -499,17 +470,13 @@ export const extractByCollectionERC1155 = async (
                 //       abiValue: instanceId,
                 //     },
                 //     {
-                //       kind: "quantity",
-                //       abiType: "uint16",
+                //       kind: "unknown",
+                //       abiType: "uint32",
+                //       abiValue: 0,
                 //     },
                 //     {
                 //       kind: "unknown",
-                //       abiType: "uint32[]",
-                //       abiValue: [],
-                //     },
-                //     {
-                //       kind: "unknown",
-                //       abiType: "bytes32[][]",
+                //       abiType: "bytes32[]",
                 //       abiValue: [],
                 //     },
                 //     {
@@ -518,6 +485,39 @@ export const extractByCollectionERC1155 = async (
                 //     },
                 //   ],
                 // },
+                data: {
+                  // `mintBatch`
+                  signature: "0x26c858a4",
+                  params: [
+                    {
+                      kind: "contract",
+                      abiType: "address",
+                    },
+                    {
+                      kind: "unknown",
+                      abiType: "uint256",
+                      abiValue: instanceId,
+                    },
+                    {
+                      kind: "quantity",
+                      abiType: "uint16",
+                    },
+                    {
+                      kind: "unknown",
+                      abiType: "uint32[]",
+                      abiValue: [],
+                    },
+                    {
+                      kind: "unknown",
+                      abiType: "bytes32[][]",
+                      abiValue: [],
+                    },
+                    {
+                      kind: "recipient",
+                      abiType: "address",
+                    },
+                  ],
+                },
               },
             },
             currency: Sdk.Common.Addresses.Native[config.chainId],

--- a/packages/indexer/src/orderbook/mints/simulation.ts
+++ b/packages/indexer/src/orderbook/mints/simulation.ts
@@ -137,7 +137,6 @@ const simulateMintTxData = async (
   quantity: number,
   txData: TxData
 ) => {
-  // console.log("txData", txData)
   if (
     [
       Network.Ethereum,

--- a/packages/indexer/src/orderbook/mints/simulation.ts
+++ b/packages/indexer/src/orderbook/mints/simulation.ts
@@ -137,6 +137,7 @@ const simulateMintTxData = async (
   quantity: number,
   txData: TxData
 ) => {
+  // console.log("txData", txData)
   if (
     [
       Network.Ethereum,

--- a/packages/indexer/src/tests/mints/manifold.test.ts
+++ b/packages/indexer/src/tests/mints/manifold.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../orderbook/mints/calldata/detector/manifold";
 import { jest, describe, it, expect } from "@jest/globals";
 import * as utils from "@/events-sync/utils";
+import { simulateCollectionMint } from "@/orderbook/mints/simulation";
 
 jest.setTimeout(1000 * 1000);
 
@@ -26,5 +27,58 @@ describe("Mints - Manifold", () => {
       "0x1eb73fee2090fb1c20105d5ba887e3c3ba14a17e"
     );
     expect(infos[0].stage.includes("claim-")).not.toBe(false);
+  });
+
+  it("case-erc1155-1", async () => {
+    const transcation = await utils.fetchTransaction(
+      "0x435ff337737fe0c54d92bafb67b57693c7faf0094db5a25a928282ae66cc223e"
+    );
+    const collectionMints = await extractByTx(
+      "0x4113e83adbb02aab32bf9885c0ea097637e81d96",
+      transcation
+    );
+    for (const collectionMint of collectionMints) {
+      if (collectionMint.status === "open") {
+        const result = await simulateCollectionMint(collectionMint);
+        expect(result).toBe(true);
+      }
+    }
+    expect(collectionMints[0].stage.includes("claim-")).not.toBe(false);
+  });
+
+  it("case-erc1155-2", async () => {
+    const transcation = await utils.fetchTransaction(
+      "0xd4b6f4a4a79d74d0e1f7214865ad2a8f98a2ff6d80ebcb4e51c325fb86fd5f96"
+    );
+    const collectionMints = await extractByTx(
+      "0x59fd8a189ff66c654628949044e774518fe22034",
+      transcation
+    );
+    // console.log("collectionMints", collectionMints)
+    for (const collectionMint of collectionMints) {
+      if (collectionMint.status === "open") {
+        const result = await simulateCollectionMint(collectionMint);
+        expect(result).toBe(true);
+      }
+    }
+    expect(collectionMints[0].stage.includes("claim-")).not.toBe(false);
+  });
+
+  it("case-erc721-1", async () => {
+    const transcation = await utils.fetchTransaction(
+      "0x09d7b966ff5cdfa6e7b31dd29217a81f9139eb802f59d646cb07ba53fa858838"
+    );
+    const collectionMints = await extractByTx(
+      "0x992a3e23e4f53b4c02639913a3572f5b29b837b6",
+      transcation
+    );
+    // console.log("collectionMints", collectionMints)
+    for (const collectionMint of collectionMints) {
+      if (collectionMint.status === "open") {
+        const result = await simulateCollectionMint(collectionMint);
+        expect(result).toBe(true);
+      }
+    }
+    expect(collectionMints[0].stage.includes("claim-")).not.toBe(false);
   });
 });

--- a/packages/indexer/src/tests/mints/manifold.test.ts
+++ b/packages/indexer/src/tests/mints/manifold.test.ts
@@ -64,6 +64,24 @@ describe("Mints - Manifold", () => {
     expect(collectionMints[0].stage.includes("claim-")).not.toBe(false);
   });
 
+  it("case-erc1155-3", async () => {
+    const transcation = await utils.fetchTransaction(
+      "0x098588156053c10d4c299c91cd496d4799d4938f8f3441421f09603dcc657a35"
+    );
+    const collectionMints = await extractByTx(
+      "0x85b7e3eb2e3fbafeccdea6b69dd350f6e1c9a8e8",
+      transcation
+    );
+    // console.log("collectionMints", collectionMints);
+    for (const collectionMint of collectionMints) {
+      if (collectionMint.status === "open") {
+        const result = await simulateCollectionMint(collectionMint);
+        expect(result).toBe(true);
+      }
+    }
+    expect(collectionMints[0].stage.includes("claim-")).not.toBe(false);
+  });
+
   it("case-erc721-1", async () => {
     const transcation = await utils.fetchTransaction(
       "0x09d7b966ff5cdfa6e7b31dd29217a81f9139eb802f59d646cb07ba53fa858838"


### PR DESCRIPTION
supported two uncovered extensions:
- 0x1EB73FEE2090fB1C20105d5Ba887e3c3bA14a17E `ERC721LazyPayableClaim`
- 0xe7d3982e214f9dfd53d23a7f72851a7044072250 `ERC1155LazyPayableClaim`