### PR TITLE
feat: ditto-whitelisted-zones

### DIFF
--- a/packages/indexer/src/migrations/1701521185000_ditto_pools.sql
+++ b/packages/indexer/src/migrations/1701521185000_ditto_pools.sql
@@ -1,0 +1,16 @@
+-- Up Migration
+
+CREATE TABLE "ditto_pools" (
+  "address" BYTEA NOT NULL,
+  "template" BYTEA NOT NULL,
+  "lp_nft" BYTEA NOT NULL,
+  "permitter" INTEGER NOT NULL
+);
+
+ALTER TABLE "ditto_pools"
+  ADD CONSTRAINT "ditto_pools_pk"
+  PRIMARY KEY ("address");
+
+-- Down Migration
+
+DROP TABLE "ditto_pools";

--- a/packages/indexer/src/migrations/1701521185000_ditto_pools.sql
+++ b/packages/indexer/src/migrations/1701521185000_ditto_pools.sql
@@ -4,7 +4,7 @@ CREATE TABLE "ditto_pools" (
   "address" BYTEA NOT NULL,
   "template" BYTEA NOT NULL,
   "lp_nft" BYTEA NOT NULL,
-  "permitter" INTEGER NOT NULL
+  "permitter" BYTEA NOT NULL
 );
 
 ALTER TABLE "ditto_pools"

--- a/packages/indexer/src/models/ditto-pools/index.ts
+++ b/packages/indexer/src/models/ditto-pools/index.ts
@@ -1,0 +1,59 @@
+import { idb } from "@/common/db";
+import { fromBuffer, toBuffer } from "@/common/utils";
+
+export type DittoPool = {
+  address: string;
+  template: string;
+  lpNft: string;
+  permitter: string;
+};
+
+export const saveDittoPool = async (dittoPool: DittoPool) => {
+  await idb.none(
+    `
+      INSERT INTO ditto_pools (
+        address,
+        template,
+        lp_nft,
+        permitter
+      ) VALUES (
+        $/address/,
+        $/template/,
+        $/lp_nft/,
+        $/permitter/
+      )
+      ON CONFLICT DO NOTHING
+    `,
+    {
+      address: toBuffer(dittoPool.address),
+      template: toBuffer(dittoPool.template),
+      lp_nft: toBuffer(dittoPool.lpNft),
+      permitter: toBuffer(dittoPool.permitter),
+    }
+  );
+  return dittoPool;
+};
+
+export const getDittoPool = async (address: string): Promise<DittoPool | null> => {
+  const result = await idb.oneOrNone(
+    `
+      SELECT
+        ditto_pools.address,
+        ditto_pools.template,
+        ditto_pools.lp_nft,
+        ditto_pools.permitter
+      FROM ditto_pools
+      WHERE ditto_pools.address = $/address/
+    `,
+    { address: toBuffer(address) }
+  );
+
+  if (!result) return null;
+
+  return {
+    address,
+    template: fromBuffer(result.template),
+    lpNft: fromBuffer(result.lpNft),
+    permitter: fromBuffer(result.permitter),
+  };
+};

--- a/packages/indexer/src/sync/events/data/ditto.ts
+++ b/packages/indexer/src/sync/events/data/ditto.ts
@@ -1,0 +1,16 @@
+import { Interface } from "@ethersproject/abi";
+import { EventData } from "@/events-sync/data";
+
+export const dittoPoolInitialized: EventData = {
+  kind: "ditto",
+  subKind: "ditto-pool-initialized",
+  topic: "0x1a09ea6cde50172776f5eec38a7369da704a85b3cfad138d4bbf52a036136f72",
+  numTopics: 1,
+  abi: new Interface([
+    `event DittoPoolMainPoolInitialized(
+      address template,
+      address lpNft,
+      address permitter
+    )`,
+  ]),
+};

--- a/packages/indexer/src/sync/events/data/index.ts
+++ b/packages/indexer/src/sync/events/data/index.ts
@@ -104,7 +104,8 @@ export type EventKind =
   | "createdotfun"
   | "payment-processor-v2"
   | "erc721c-v2"
-  | "titlesxyz";
+  | "titlesxyz"
+  | "ditto";
 
 // Event sub-kind in each of the above protocol/standard
 export type EventSubKind =
@@ -341,7 +342,8 @@ export type EventSubKind =
   | "erc721c-v2-added-code-hash-to-list"
   | "erc721c-v2-removed-account-from-list"
   | "erc721c-v2-removed-code-hash-from-list"
-  | "erc721c-v2-applied-list-to-collection";
+  | "erc721c-v2-applied-list-to-collection"
+  | "ditto-pool-initialized";
 
 export type EventData = {
   kind: EventKind;

--- a/packages/indexer/src/sync/events/handlers/ditto.ts
+++ b/packages/indexer/src/sync/events/handlers/ditto.ts
@@ -1,0 +1,28 @@
+import { getEventData } from "@/events-sync/data";
+import { EnhancedEvent } from "@/events-sync/handlers/utils";
+import { DittoPool, saveDittoPool } from "@/models/ditto-pools";
+
+export const handleEvents = async (events: EnhancedEvent[]) => {
+  // Handle the events
+  for (const { subKind, baseEventParams, log } of events) {
+    const eventData = getEventData([subKind])[0];
+    switch (subKind) {
+      case "ditto-pool-initialized": {
+        const parsedLog = eventData.abi.parseLog(log);
+        const poolAddress = baseEventParams.address.toLowerCase();
+        const templateAddress = parsedLog.args["template"].toLowerCase();
+        const lpNftAddress = parsedLog.args["lpNft"].toLowerCase();
+        const permitterAddress = parsedLog.args["permitter"].toLowerCase();
+        const dittoPool: DittoPool = {
+          address: poolAddress,
+          template: templateAddress,
+          lpNft: lpNftAddress,
+          permitter: permitterAddress,
+        };
+        await saveDittoPool(dittoPool);
+
+        break;
+      }
+    }
+  }
+};


### PR DESCRIPTION
We want Reservoir to dynamically whitelist Ditto pools (which implements SIP7: https://github.com/ProjectOpenSea/SIPs/blob/main/SIPS/sip-7.md) based on on-chain events.

This PR will do this by:
- Creating a "ditto_pools" table storing the zone address plus some additional metadata columns included in the event.
- Defining the event in the indexer
- Creating a handler for the pool creation event which inserts a row into "ditto_pools" for every detected event.

This enables Reservoir to check if the zone address for incoming seaport orders is whitelisted by searching this table.