### PR TITLE
feat: define max limits for contract/collection set ids

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/post-create-collections-set/v1.ts
+++ b/packages/indexer/src/api/endpoints/collections/post-create-collections-set/v1.ts
@@ -10,7 +10,7 @@ const version = "v1";
 export const postCreateCollectionsSetV1Options: RouteOptions = {
   description: "Create collection set",
   notes:
-    'Array of collections to gather in a set. Adding or removing a collection will change the response. You may use this set when `collectionSetId` is an available param. An example is below.\n\n`"collections": "0xba30E5F9Bb24caa003E9f2f0497Ad287FDF95623", "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D"`\n\n`"collectionsSetId": "8daa732ebe5db23f267e58d52f1c9b1879279bcdf4f78b8fb563390e6946ea65"`',
+    'Array of collections to gather in a set. Adding or removing a collection will change the response. You may use this set when `collectionSetId` is an available param. The max limit of collection in an array is 500. An example is below.\n\n`"collections": "0xba30E5F9Bb24caa003E9f2f0497Ad287FDF95623", "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D"`\n\n`"collectionsSetId": "8daa732ebe5db23f267e58d52f1c9b1879279bcdf4f78b8fb563390e6946ea65"`',
   tags: ["api", "Collections"],
   plugins: {
     "hapi-swagger": {

--- a/packages/indexer/src/api/endpoints/contracts-sets/post-create-contracts-set/v1.ts
+++ b/packages/indexer/src/api/endpoints/contracts-sets/post-create-contracts-set/v1.ts
@@ -11,7 +11,7 @@ const version = "v1";
 export const postCreateContractsSetV1Options: RouteOptions = {
   description: "Create contracts set",
   notes:
-    "Array of contracts to gather in a set. Adding or removing a contract will change the response. You may use this set when contractSetId is an available param.",
+    "Array of contracts to gather in a set. Adding or removing a contract will change the response. You may use this set when contractSetId is an available param. Max limit of contracts passed in an array is 500. An example is below.\n\n`"contracts": "0x60e4d786628fea6478f785a6d7e704777c86a7c6", "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"`\n\n`"contractsSetId": "74cc9bdc0824e92de13c75213015916557fcf8187e43b34a8e77175cd03d1931"`",
   tags: ["api", "Collections"],
   plugins: {
     "hapi-swagger": {


### PR DESCRIPTION
- Added max limit to API description for create collectionsSetId (500)
- Added max limit to API description for create contractsSetId (500)
- Added example to API description for create contractsSetId