### PR TITLE
Fix Trending Collections metadata cache not breaking

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/get-trending-collections/v1.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-trending-collections/v1.ts
@@ -173,7 +173,7 @@ export async function getCollectionsMetadata(
   floorAskPercentChange?: string
 ) {
   const collectionIds = collectionsResult.map((collection: any) => collection.id);
-  const collectionsToFetch = collectionIds.map((id: string) => `collection-cache:v3:${id}`);
+  const collectionsToFetch = collectionIds.map((id: string) => `collection-cache:v4:${id}`);
   const batches = chunk(collectionsToFetch, REDIS_BATCH_SIZE);
   const tasks = batches.map(async (batch) => redis.mget(batch));
   const results = await Promise.all(tasks);
@@ -298,8 +298,8 @@ export async function getCollectionsMetadata(
 
     const commands = flatMap(collectionMetadataResponse, (metadata: any) => {
       return [
-        ["set", `collection-cache:v3:${metadata.id}`, JSON.stringify(metadata)],
-        ["expire", `collection-cache:v3:${metadata.id}`, REDIS_EXPIRATION],
+        ["set", `collection-cache:v4:${metadata.id}`, JSON.stringify(metadata)],
+        ["expire", `collection-cache:v4:${metadata.id}`, REDIS_EXPIRATION],
       ];
     });
 

--- a/packages/indexer/src/jobs/cdc/topics/indexer-collections.ts
+++ b/packages/indexer/src/jobs/cdc/topics/indexer-collections.ts
@@ -61,7 +61,7 @@ export class IndexerCollectionsHandler extends KafkaEventHandler {
     });
 
     try {
-      const collectionKey = `collection-cache:v2:${payload.after.id}`;
+      const collectionKey = `collection-cache:v4:${payload.after.id}`;
 
       const cachedCollection = await redis.get(collectionKey);
 


### PR DESCRIPTION
Upgrade the collection key to v4 to break the current cache (so that we don't have to wait for the expiry).
