### PR TITLE
feat: refine collections/v7 param descriptions

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/get-collections/v7.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-collections/v7.ts
@@ -45,7 +45,7 @@ export const getCollectionsV7Options: RouteOptions = {
       id: Joi.string()
         .lowercase()
         .description(
-          "Filter to a particular collection with collection id. Example: `0x8d04a8c79ceb0889bdd12acdf3fa9d207ed3ff63`"
+          "Filter to a particular collection with collection id. The id is immutable.\n For single contract collections, the id is the contract address e.g. `0x8d04a8c79ceb0889bdd12acdf3fa9d207ed3ff63`\n Artblocks will follow this format with a token range: `0x059edd72cd353df5106d2b9cc5ab83a52287ac3a:{startTokenId}:{endTokenId}`\n Shared contracts will generally follow the format `{contract}:{namespace}-{id}`; The following shared contracts will follow this format:\n OpenSea, Sound, SuperRare, Foundation, Ordinals, & Courtyard"
         ),
       slug: Joi.string().description(
         "Filter to a particular collection slug. Example: `boredapeyachtclub`"

--- a/packages/indexer/src/api/endpoints/collections/get-collections/v7.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-collections/v7.ts
@@ -48,7 +48,7 @@ export const getCollectionsV7Options: RouteOptions = {
           "Filter to a particular collection with collection id. The id is immutable.\n For single contract collections, the id is the contract address e.g. `0x8d04a8c79ceb0889bdd12acdf3fa9d207ed3ff63`\n Artblocks will follow this format with a token range: `0x059edd72cd353df5106d2b9cc5ab83a52287ac3a:{startTokenId}:{endTokenId}`\n Shared contracts will generally follow the format `{contract}:{namespace}-{id}`; The following shared contracts will follow this format:\n OpenSea, Sound, SuperRare, Foundation, Ordinals, & Courtyard"
         ),
       slug: Joi.string().description(
-        "Filter to a particular collection slug. Example: `boredapeyachtclub`"
+        "Filter to a particular collection slug. We recommend to rely on collection id; slugs are dynamic and can change without warning. Example: `boredapeyachtclub`"
       ),
       collectionsSetId: Joi.string()
         .lowercase()


### PR DESCRIPTION
- Added clarification for how collection-id are formatted (contract vs artblocks vs shared contracts)
- Added clarification slugs are dynamic & user should rely on collection-id instead