### PR TITLE
Fix: remove "Trader" tag on all execute APIs

### DIFF
--- a/packages/indexer/src/api/endpoints/execute/get-execute-bid/v5.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-bid/v5.ts
@@ -69,7 +69,7 @@ export const getExecuteBidV5Options: RouteOptions = {
   notes:
     "Generate bids and submit them to multiple marketplaces.\n\n Notes:\n\n- Please use the `/cross-posting-orders/v1` to check the status on cross posted bids.\n\n- We recommend using Reservoir SDK as it abstracts the process of iterating through steps, and returning callbacks that can be used to update your UI.",
   timeout: { server: 60000 },
-  tags: ["api", "Trading"],
+  tags: ["api"],
   plugins: {
     "hapi-swagger": {
       order: 11,

--- a/packages/indexer/src/api/endpoints/execute/get-execute-buy/v7.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-buy/v7.ts
@@ -55,7 +55,7 @@ export const getExecuteBuyV7Options: RouteOptions = {
   description: "Buy Tokens",
   notes:
     "Use this API to fill listings. We recommend using the SDK over this API as the SDK will iterate through the steps and return callbacks. Please mark `excludeEOA` as `true` to exclude Blur orders.",
-  tags: ["api", "Trading"],
+  tags: ["api"],
   timeout: {
     server: 40 * 1000,
   },

--- a/packages/indexer/src/api/endpoints/execute/get-execute-cancel/v3.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-cancel/v3.ts
@@ -21,7 +21,7 @@ const version = "v3";
 export const getExecuteCancelV3Options: RouteOptions = {
   description: "Cancel Orders",
   notes: "Cancel existing orders on any marketplace",
-  tags: ["api", "Trading"],
+  tags: ["api"],
   plugins: {
     "hapi-swagger": {
       order: 11,

--- a/packages/indexer/src/api/endpoints/execute/get-execute-list/v5.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-list/v5.ts
@@ -58,7 +58,7 @@ export const getExecuteListV5Options: RouteOptions = {
   description: "Create Listings",
   notes:
     "Generate listings and submit them to multiple marketplaces.\n\n Notes:\n\n- Please use the `/cross-posting-orders/v1` to check the status on cross posted bids.\n\n- We recommend using Reservoir SDK as it abstracts the process of iterating through steps, and returning callbacks that can be used to update your UI.",
-  tags: ["api", "Trading"],
+  tags: ["api"],
   plugins: {
     "hapi-swagger": {
       order: 11,

--- a/packages/indexer/src/api/endpoints/execute/get-execute-sell/v7.ts
+++ b/packages/indexer/src/api/endpoints/execute/get-execute-sell/v7.ts
@@ -41,7 +41,7 @@ export const getExecuteSellV7Options: RouteOptions = {
   description: "Sell Tokens",
   notes:
     "Use this API to accept bids. We recommend using the SDK over this API as the SDK will iterate through the steps and return callbacks. Please mark `excludeEOA` as `true` to exclude Blur orders.",
-  tags: ["api", "Trading"],
+  tags: ["api"],
   timeout: {
     server: 40 * 1000,
   },

--- a/packages/indexer/src/api/endpoints/execute/post-execute-mint/v1.ts
+++ b/packages/indexer/src/api/endpoints/execute/post-execute-mint/v1.ts
@@ -34,7 +34,7 @@ export const postExecuteMintV1Options: RouteOptions = {
   description: "Mint Tokens",
   notes:
     "Use this API to mint tokens. We recommend using the SDK over this API as the SDK will iterate through the steps and return callbacks.",
-  tags: ["api", "Trading"],
+  tags: ["api"],
   timeout: {
     server: 40 * 1000,
   },

--- a/packages/indexer/src/api/endpoints/execute/post-execute-transfer/v1.ts
+++ b/packages/indexer/src/api/endpoints/execute/post-execute-transfer/v1.ts
@@ -14,7 +14,7 @@ const version = "v1";
 export const postExecuteTransferV1Options: RouteOptions = {
   description: "Transfer Tokens",
   notes: "Use this endpoint to bulk transfer an array of NFTs.",
-  tags: ["api", "Trading"],
+  tags: ["api"],
   plugins: {
     "hapi-swagger": {
       order: 50,

--- a/packages/indexer/src/api/endpoints/orders/get-cross-posting-orders/v1.ts
+++ b/packages/indexer/src/api/endpoints/orders/get-cross-posting-orders/v1.ts
@@ -13,7 +13,7 @@ export const getCrossPostingOrdersV1Options: RouteOptions = {
   description: "Check Cross Posting Status",
   notes:
     "This API can be used to check the status of cross posted listings and bids.\n\n Input your `crossPostingOrderId` into the `ids` param and submit for the status. \n\n The `crossPostingOrderId` is returned in the `execute/bids` and `execute/asks` response as well as the `onProgess` callback for the SDK. \n\n Note: ReservoirKit does not return a `crossPostingOrderId`.",
-  tags: ["api", "Trading", "Manage Orders"],
+  tags: ["api", "Manage Orders"],
   plugins: {
     "hapi-swagger": {
       order: 5,

--- a/packages/indexer/src/api/endpoints/orders/post-order/v4.ts
+++ b/packages/indexer/src/api/endpoints/orders/post-order/v4.ts
@@ -20,7 +20,7 @@ const version = "v4";
 
 export const postOrderV4Options: RouteOptions = {
   description: "Submit Signed Orders",
-  tags: ["api", "Trading", "Manage Orders"],
+  tags: ["api", "Manage Orders"],
   plugins: {
     "hapi-swagger": {
       order: 5,

--- a/packages/indexer/src/api/endpoints/transactions/get-transaction-synced/v1.ts
+++ b/packages/indexer/src/api/endpoints/transactions/get-transaction-synced/v1.ts
@@ -10,7 +10,7 @@ const version = "v1";
 export const getTransactionSyncedV1Options: RouteOptions = {
   description: "Check Transaction Status",
   notes: "Get a boolean response on whether a particular transaction was synced or not.",
-  tags: ["api", "Trading", "Manage Orders"],
+  tags: ["api", "Manage Orders"],
   plugins: {
     "hapi-swagger": {
       order: 10,


### PR DESCRIPTION
Removed "Trading" tag from all execute APIs; should remove folder in readMe.