### PR TITLE
feat: add memory cache for swagger endpoints

### DIFF
--- a/packages/indexer/src/api/endpoints/admin/get-open-api.ts
+++ b/packages/indexer/src/api/endpoints/admin/get-open-api.ts
@@ -198,6 +198,9 @@ export const getOpenApiOptions: RouteOptions = {
   timeout: {
     server: 10 * 1000,
   },
+  cache: {
+    expiresIn: 7 * 24 * 60 * 60 * 1000,
+  },
   handler: async () => {
     try {
       if (!openapiData) {

--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -133,6 +133,9 @@ export const start = async (): Promise<void> => {
         cors: true,
         tryItOutEnabled: true,
         documentationPath: "/",
+        cache: {
+          expiresIn: 7 * 24 * 60 * 60 * 1000,
+        },
         sortEndpoints: "ordered",
         info: {
           title: "Reservoir API",


### PR DESCRIPTION
Adds basic in memory cache for swagger.json(from HapiSwagger) and /admin/open-api endpoints. 

Swagger generation can take up to 20 seconds from my experience which is a lot, often causing timeouts in code generating libraries like Orval. This just caches them in memory using the default Hapi memory implementation. Especially annoying if you often use Swagger UI to test requests or do stuff.

Chosen a week since it will re-generate after each restart anyway, can change to whatever you find suitable.