### PR TITLE
fix(nftx-v3): combine all tokens into 1 quote

### DIFF
--- a/packages/indexer/src/orderbook/orders/nftx-v3/index.ts
+++ b/packages/indexer/src/orderbook/orders/nftx-v3/index.ts
@@ -159,15 +159,24 @@ export const save = async (orderInfos: OrderInfo[]): Promise<SaveResult[]> => {
 
           if (priceList.length) {
             // Get the price of buying this specific token id
-            const { price, executeCallData } = await Sdk.NftxV3.Helpers.getPoolQuoteFromAPI({
-              provider: baseProvider,
-              vault: orderParams.pool,
-              side: "sell",
-              slippage,
-              tokenIds: [orderParams.tokenId],
-              userAddress,
-              nftxApiKey: config.nftxApiKey,
-            });
+            const { price, executeCallData } = orderParams.tokenId
+              ? await Sdk.NftxV3.Helpers.getPoolQuoteFromAPI({
+                  provider: baseProvider,
+                  vault: orderParams.pool,
+                  side: "sell",
+                  slippage,
+                  tokenIds: [orderParams.tokenId],
+                  userAddress,
+                  nftxApiKey: config.nftxApiKey,
+                })
+              : await Sdk.NftxV3.Helpers.getPoolPriceFromAPI({
+                  nftxApiKey: config.nftxApiKey,
+                  provider: baseProvider,
+                  vault: orderParams.pool,
+                  side: "sell",
+                  slippage,
+                  tokenIds: ["-1"],
+                });
             const value = bn(price).toString();
 
             // Get the price impact of buying 1-50 items

--- a/packages/indexer/src/sync/events/handlers/nftx-v3.ts
+++ b/packages/indexer/src/sync/events/handlers/nftx-v3.ts
@@ -505,7 +505,6 @@ export const handleEvents = async (events: EnhancedEvent[], onChainData: OnChain
         break;
       }
 
-      case "nftx-minted":
       case "nftx-v3-swap": {
         const ftPool = await nftxV3Utils.getFtPoolDetails(baseEventParams.address, true, "nftx-v3");
         if (ftPool) {


### PR DESCRIPTION
the execution call data for nftx orders needs to only be a single quote combining all token ids for each vault id

