### PR TITLE
Devo 163 fix cache control

### DIFF
--- a/packages/indexer/src/api/endpoints/assets/get-asset/v1.ts
+++ b/packages/indexer/src/api/endpoints/assets/get-asset/v1.ts
@@ -39,7 +39,7 @@ export const getAssetV1Options: RouteOptions = {
 
       return response
         .redirect(imageWithQueryParams)
-        .header("cache-control", `${1000 * 60 * 60 * 24 * 30}`);
+        .header("cache-control", `max-age=${60 * 60 * 24 * 30}, must-revalidate, public`);
     } catch (error) {
       logger.error(
         `get-asset-${version}-handler`,
@@ -47,7 +47,7 @@ export const getAssetV1Options: RouteOptions = {
       );
 
       const err = Boom.notFound(`Asset not found`);
-      err.output.headers["cache-control"] = `${1000 * 60 * 60 * 24}`;
+      err.output.headers["cache-control"] = `max-age=${60 * 60 * 24}, must-revalidate, public`;
       throw err;
     }
   },

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-collection-image/v1.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-collection-image/v1.ts
@@ -47,6 +47,6 @@ export const getRedirectCollectionImageV1Options: RouteOptions = {
       request.query
     );
 
-    return response.redirect(imageWithQueryParams).header("cache-control", `${1000 * 60}`);
+    return response.redirect(imageWithQueryParams).header("cache-control", `max-age=60, must-revalidate, public`);
   },
 };

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-currency-icon/v1.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-currency-icon/v1.ts
@@ -40,7 +40,7 @@ export const getRedirectCurrencyIconV1Options: RouteOptions = {
       const currency = await getCurrency(params.address);
       const currencyIconImage = currency?.metadata?.image;
       if (currencyIconImage) {
-        return response.redirect(currencyIconImage).header("cache-control", `${1000 * 60}`);
+        return response.redirect(currencyIconImage).header("cache-control", `max-age=60, must-revalidate, public`);
       }
     } catch (error) {
       logger.error(`get-redirect-currency-icon-${version}-handler`, `Handler failure: ${error}`);

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-logo/v1.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-logo/v1.ts
@@ -36,7 +36,7 @@ export const getRedirectLogoV1Options: RouteOptions = {
         source = sources.getByDomain(query.source);
       }
 
-      return response.redirect(source?.getIcon()).header("cache-control", `${1000 * 60}`);
+      return response.redirect(source?.getIcon()).header("cache-control", `max-age=60, must-revalidate, public`);
     } catch (error) {
       logger.error(`get-redirect-logo-${version}-handler`, `Handler failure: ${error}`);
       throw error;

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-logo/v2.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-logo/v2.ts
@@ -35,7 +35,7 @@ export const getRedirectLogoV2Options: RouteOptions = {
         source = sources.getByDomain(params.source);
       }
 
-      return response.redirect(source?.getIcon()).header("cache-control", `${1000 * 60}`);
+      return response.redirect(source?.getIcon()).header("cache-control", `max-age=60, must-revalidate, public`);
     } catch (error) {
       logger.error(`get-redirect-logo-${version}-handler`, `Handler failure: ${error}`);
       throw error;

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-token-image/v1.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-token-image/v1.ts
@@ -63,7 +63,7 @@ export const getRedirectTokenImageV1Options: RouteOptions = {
 
       delete request.query.imageSize;
       const imageWithQueryParams = Assets.addImageParams(imageUrl, request.query);
-      return response.redirect(imageWithQueryParams).header("cache-control", `${1000 * 60}`);
+      return response.redirect(imageWithQueryParams).header("cache-control", `max-age=60, must-revalidate, public`);
     } catch (error) {
       logger.error(`get-redirect-token-image-${version}-handler`, `Handler failure: ${error}`);
       throw error;

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-token/v1.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-token/v1.ts
@@ -52,7 +52,7 @@ export const getRedirectTokenV1Options: RouteOptions = {
       const tokenUrl = sources.getTokenUrl(source, contract, tokenId);
 
       if (tokenUrl) {
-        return response.redirect(tokenUrl).header("cache-control", `${1000 * 60}`);
+        return response.redirect(tokenUrl).header("cache-control", `max-age=60, must-revalidate, public`);
       }
 
       let redirectUrl = source.domain;
@@ -60,7 +60,7 @@ export const getRedirectTokenV1Options: RouteOptions = {
         redirectUrl = `https://${redirectUrl}`;
       }
 
-      return response.redirect(redirectUrl).header("cache-control", `${1000 * 60}`);
+      return response.redirect(redirectUrl).header("cache-control", `max-age=60, must-revalidate, public`);
     } catch (error) {
       logger.error(`get-redirect-token-${version}-handler`, `Handler failure: ${error}`);
       throw error;

--- a/packages/indexer/src/api/endpoints/redirects/get-redirect-token/v2.ts
+++ b/packages/indexer/src/api/endpoints/redirects/get-redirect-token/v2.ts
@@ -51,7 +51,7 @@ export const getRedirectTokenV2Options: RouteOptions = {
       const tokenUrl = sources.getTokenUrl(source, contract, tokenId);
 
       if (tokenUrl) {
-        return response.redirect(tokenUrl).header("cache-control", `${1000 * 60}`);
+        return response.redirect(tokenUrl).header("cache-control", `max-age=60, must-revalidate, public`);
       }
 
       let redirectUrl = source.domain;
@@ -59,7 +59,7 @@ export const getRedirectTokenV2Options: RouteOptions = {
         redirectUrl = `https://${redirectUrl}`;
       }
 
-      return response.redirect(redirectUrl).header("cache-control", `${1000 * 60}`);
+      return response.redirect(redirectUrl).header("cache-control", `max-age=60, must-revalidate, public`);
     } catch (error) {
       logger.error(`get-redirect-token-${version}-handler`, `Handler failure: ${error}`);
       throw error;

--- a/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v9.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v9.ts
@@ -1027,7 +1027,7 @@ export const getUserTokensV9Options: RouteOptions = {
           tokens: await Promise.all(result),
           continuation,
         })
-        .header("cache-control", `${cacheControl}`);
+        .header("cache-control", `max-age=${cacheControl}, must-revalidate, public`);
     } catch (error) {
       logger.error(`get-user-tokens-${version}-handler`, `Handler failure: ${error}`);
       throw error;

--- a/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v9.ts
+++ b/packages/indexer/src/api/endpoints/tokens/get-user-tokens/v9.ts
@@ -482,12 +482,14 @@ export const getUserTokensV9Options: RouteOptions = {
         ${includeRoyaltyBreakdownQuery}
         WHERE b.token_id = t.token_id
         AND b.contract = t.contract
-        ${tokensConditions.length
-        ? "AND " + tokensConditions.map((c) => `(${c})`).join(" AND ")
-        : ""
-      }
-        AND ${tokensCollectionFilters.length ? "(" + tokensCollectionFilters.join(" OR ") + ")" : "TRUE"
-      }
+        ${
+          tokensConditions.length
+            ? "AND " + tokensConditions.map((c) => `(${c})`).join(" AND ")
+            : ""
+        }
+        AND ${
+          tokensCollectionFilters.length ? "(" + tokensCollectionFilters.join(" OR ") + ")" : "TRUE"
+        }
       ) t ON TRUE
     `;
 
@@ -525,14 +527,16 @@ export const getUserTokensV9Options: RouteOptions = {
           ${includeRoyaltyBreakdownQuery}
           WHERE b.token_id = t.token_id
           AND b.contract = t.contract
-          ${tokensConditions.length
-          ? "AND " + tokensConditions.map((c) => `(${c})`).join(" AND ")
-          : ""
-        }
-          AND ${tokensCollectionFilters.length
-          ? "(" + tokensCollectionFilters.join(" OR ") + ")"
-          : "TRUE"
-        }
+          ${
+            tokensConditions.length
+              ? "AND " + tokensConditions.map((c) => `(${c})`).join(" AND ")
+              : ""
+          }
+          AND ${
+            tokensCollectionFilters.length
+              ? "(" + tokensCollectionFilters.join(" OR ") + ")"
+              : "TRUE"
+          }
         ) t ON TRUE
         LEFT JOIN LATERAL (
           SELECT
@@ -626,14 +630,17 @@ export const getUserTokensV9Options: RouteOptions = {
       (query as any).tokenId = tokenId;
       query.sortDirection = query.sortDirection || "desc";
       if (query.sortBy === "acquiredAt") {
-        continuationFilter = ` AND (acquired_at, nft_balances.token_id) ${query.sortDirection == "desc" ? "<" : ">"
-          } (to_timestamp($/sortByValue/), $/tokenId/)`;
+        continuationFilter = ` AND (acquired_at, nft_balances.token_id) ${
+          query.sortDirection == "desc" ? "<" : ">"
+        } (to_timestamp($/sortByValue/), $/tokenId/)`;
       } else if (query.sortBy === "lastAppraisalValue") {
-        continuationFilter = `AND (last_token_appraisal_value, nft_balances.token_id) ${query.sortDirection == "desc" ? "<" : ">"
-          } ($/sortByValue/, $/tokenId/)`;
+        continuationFilter = `AND (last_token_appraisal_value, nft_balances.token_id) ${
+          query.sortDirection == "desc" ? "<" : ">"
+        } ($/sortByValue/, $/tokenId/)`;
       } else if (query.sortBy === "floorAskPrice") {
-        continuationFilter = `AND (c.floor_sell_value, nft_balances.token_id) ${query.sortDirection == "desc" ? "<" : ">"
-          } ($/sortByValue/, $/tokenId/)`;
+        continuationFilter = `AND (c.floor_sell_value, nft_balances.token_id) ${
+          query.sortDirection == "desc" ? "<" : ">"
+        } ($/sortByValue/, $/tokenId/)`;
       }
     }
 
@@ -648,9 +655,10 @@ export const getUserTokensV9Options: RouteOptions = {
         ${!_.isEmpty(collections) ? `AND uc.collection_id IN ($/collections:list/)` : ""}
         ${query.excludeSpam ? `AND (uc.is_spam IS NULL OR uc.is_spam <= 0)` : ""}
         ${query.excludeNsfw ? ` AND (c.nsfw_status IS NULL OR c.nsfw_status <= 0)` : ""}
-        ${query.sortBy === "floorAskPrice"
-          ? `ORDER BY floor_sell_value ${query.sortDirection} NULLS LAST`
-          : ""
+        ${
+          query.sortBy === "floorAskPrice"
+            ? `ORDER BY floor_sell_value ${query.sortDirection} NULLS LAST`
+            : ""
         }
       `;
     }
@@ -681,10 +689,11 @@ export const getUserTokensV9Options: RouteOptions = {
                 COALESCE(nullif(date_part('epoch', upper(ot.valid_between)), 'Infinity'), 0) AS "floor_sell_valid_to",
                ot.source_id_int as floor_sell_source_id_int, ot.id as floor_sell_id,
                ${query.includeRawData ? "ot.raw_data AS floor_sell_raw_data," : ""}
-               ${query.useNonFlaggedFloorAsk
-          ? "c.floor_sell_value"
-          : "c.non_flagged_floor_sell_value"
-        } AS "collection_floor_sell_value",
+               ${
+                 query.useNonFlaggedFloorAsk
+                   ? "c.floor_sell_value"
+                   : "c.non_flagged_floor_sell_value"
+               } AS "collection_floor_sell_value",
                (
                     CASE WHEN ot.value IS NOT NULL
                     THEN 1
@@ -696,38 +705,46 @@ export const getUserTokensV9Options: RouteOptions = {
             ${ucTable ? `(${ucTable}) AS c JOIN LATERAL ` : ""} (
             SELECT amount AS token_count, nft_balances.token_id, nft_balances.contract, acquired_at, last_token_appraisal_value
             FROM nft_balances
-            ${ucTable
-          ? `JOIN tokens t on nft_balances.contract = t.contract AND nft_balances.token_id = t.token_id AND CASE WHEN c.shared_contract IS TRUE THEN c.collection_id = t.collection_id ELSE true END`
-          : ""
-        }
+            ${
+              ucTable
+                ? `JOIN tokens t on nft_balances.contract = t.contract AND nft_balances.token_id = t.token_id AND CASE WHEN c.shared_contract IS TRUE THEN c.collection_id = t.collection_id ELSE true END`
+                : ""
+            }
             WHERE owner = $/user/
-              AND ${tokensFilter.length
-          ? "(nft_balances.contract, nft_balances.token_id) IN ($/tokensFilter:raw/)"
-          : "TRUE"
-        }
+              AND ${
+                tokensFilter.length
+                  ? "(nft_balances.contract, nft_balances.token_id) IN ($/tokensFilter:raw/)"
+                  : "TRUE"
+              }
               AND amount > 0
-              ${ucTable
-          ? `AND nft_balances.contract = c.contract`
-          : `AND ${nftBalanceCollectionFilters.length
-            ? "(" + nftBalanceCollectionFilters.join(" OR ") + ")"
-            : "TRUE"
-          }`
-        }
+              ${
+                ucTable
+                  ? `AND nft_balances.contract = c.contract`
+                  : `AND ${
+                      nftBalanceCollectionFilters.length
+                        ? "(" + nftBalanceCollectionFilters.join(" OR ") + ")"
+                        : "TRUE"
+                    }`
+              }
               ${continuationFilter}
               ${nftBalanceSorting}
               ${limitFullResultsSet ? "" : limit}
           ) AS b ${ucTable ? ` ON TRUE` : ""}
           ${tokensJoin}
-          ${ucTable
-          ? ""
-          : `${listBasedContract || query.excludeSpam || query.excludeNsfw ? "" : "LEFT "
-          }JOIN collections c ON c.id = t.collection_id ${query.excludeSpam ? `AND (c.is_spam IS NULL OR c.is_spam <= 0)` : ""
-          }${query.excludeNsfw ? ` AND (c.nsfw_status IS NULL OR c.nsfw_status <= 0)` : ""}`
-        }
+          ${
+            ucTable
+              ? ""
+              : `${
+                  listBasedContract || query.excludeSpam || query.excludeNsfw ? "" : "LEFT "
+                }JOIN collections c ON c.id = t.collection_id ${
+                  query.excludeSpam ? `AND (c.is_spam IS NULL OR c.is_spam <= 0)` : ""
+                }${query.excludeNsfw ? ` AND (c.nsfw_status IS NULL OR c.nsfw_status <= 0)` : ""}`
+          }
           LEFT JOIN orders o ON o.id = c.floor_sell_id
           LEFT JOIN contracts con ON b.contract = con.address
-          ${query.onlyListed ? "" : "LEFT"
-        } JOIN orders ot ON ot.id = CASE WHEN con.kind = 'erc1155' THEN (
+          ${
+            query.onlyListed ? "" : "LEFT"
+          } JOIN orders ot ON ot.id = CASE WHEN con.kind = 'erc1155' THEN (
             SELECT
               id
             FROM
@@ -757,26 +774,26 @@ export const getUserTokensV9Options: RouteOptions = {
         if (query.sortBy === "acquiredAt") {
           continuation = buildContinuation(
             _.toInteger(userTokens[userTokens.length - 1].acquired_at) +
-            "_" +
-            userTokens[userTokens.length - 1].collection_id +
-            "_" +
-            userTokens[userTokens.length - 1].token_id
+              "_" +
+              userTokens[userTokens.length - 1].collection_id +
+              "_" +
+              userTokens[userTokens.length - 1].token_id
           );
         } else if (query.sortBy === "lastAppraisalValue") {
           continuation = buildContinuation(
             _.toInteger(userTokens[userTokens.length - 1].last_token_appraisal_value) +
-            "_" +
-            userTokens[userTokens.length - 1].collection_id +
-            "_" +
-            userTokens[userTokens.length - 1].token_id
+              "_" +
+              userTokens[userTokens.length - 1].collection_id +
+              "_" +
+              userTokens[userTokens.length - 1].token_id
           );
         } else if (query.sortBy === "floorAskPrice") {
           continuation = buildContinuation(
             userTokens[userTokens.length - 1].collection_floor_sell_currency_price +
-            "_" +
-            userTokens[userTokens.length - 1].collection_id +
-            "_" +
-            userTokens[userTokens.length - 1].token_id
+              "_" +
+              userTokens[userTokens.length - 1].collection_id +
+              "_" +
+              userTokens[userTokens.length - 1].token_id
           );
         }
       }
@@ -868,17 +885,17 @@ export const getUserTokensV9Options: RouteOptions = {
                 openseaVerificationStatus: r.opensea_verification_status,
                 floorAskPrice: r.collection_floor_sell_value
                   ? await getJoiPriceObject(
-                    {
-                      gross: {
-                        amount: String(
-                          r.collection_floor_sell_currency_price ?? r.collection_floor_sell_value
-                        ),
-                        nativeAmount: String(r.collection_floor_sell_value),
+                      {
+                        gross: {
+                          amount: String(
+                            r.collection_floor_sell_currency_price ?? r.collection_floor_sell_value
+                          ),
+                          nativeAmount: String(r.collection_floor_sell_value),
+                        },
                       },
-                    },
-                    collectionFloorSellCurrency,
-                    query.displayCurrency
-                  )
+                      collectionFloorSellCurrency,
+                      query.displayCurrency
+                    )
                   : null,
                 royaltiesBps: r.royalties_bps ?? 0,
                 royalties: r.royalties
@@ -888,45 +905,45 @@ export const getUserTokensV9Options: RouteOptions = {
               lastSale:
                 query.includeLastSale && r.last_sale_currency
                   ? await getJoiSaleObject({
-                    prices: {
-                      gross: {
-                        amount: r.last_sale_currency_price ?? r.last_sale_price,
-                        nativeAmount: r.last_sale_price,
-                        usdAmount: r.last_sale_usd_price,
+                      prices: {
+                        gross: {
+                          amount: r.last_sale_currency_price ?? r.last_sale_price,
+                          nativeAmount: r.last_sale_price,
+                          usdAmount: r.last_sale_usd_price,
+                        },
                       },
-                    },
-                    fees: {
-                      royaltyFeeBps: r.last_sale_royalty_fee_bps,
-                      marketplaceFeeBps: r.last_sale_marketplace_fee_bps,
-                      paidFullRoyalty: r.last_sale_paid_full_royalty,
-                      royaltyFeeBreakdown: r.last_sale_royalty_fee_breakdown,
-                      marketplaceFeeBreakdown: r.last_sale_marketplace_fee_breakdown,
-                    },
-                    currencyAddress: r.last_sale_currency,
-                    timestamp: r.last_sale_timestamp,
-                  })
+                      fees: {
+                        royaltyFeeBps: r.last_sale_royalty_fee_bps,
+                        marketplaceFeeBps: r.last_sale_marketplace_fee_bps,
+                        paidFullRoyalty: r.last_sale_paid_full_royalty,
+                        royaltyFeeBreakdown: r.last_sale_royalty_fee_breakdown,
+                        marketplaceFeeBreakdown: r.last_sale_marketplace_fee_breakdown,
+                      },
+                      currencyAddress: r.last_sale_currency,
+                      timestamp: r.last_sale_timestamp,
+                    })
                   : undefined,
               topBid: query.includeTopBid
                 ? {
-                  id: r.top_bid_id,
-                  price: r.top_bid_value
-                    ? await getJoiPriceObject(
-                      {
-                        net: {
-                          amount: r.top_bid_currency_value ?? r.top_bid_value,
-                          nativeAmount: r.top_bid_value,
-                        },
-                        gross: {
-                          amount: r.top_bid_currency_price ?? r.top_bid_price,
-                          nativeAmount: r.top_bid_price,
-                        },
-                      },
-                      topBidCurrency,
-                      query.displayCurrency
-                    )
-                    : null,
-                  source: getJoiSourceObject(topBidSource),
-                }
+                    id: r.top_bid_id,
+                    price: r.top_bid_value
+                      ? await getJoiPriceObject(
+                          {
+                            net: {
+                              amount: r.top_bid_currency_value ?? r.top_bid_value,
+                              nativeAmount: r.top_bid_value,
+                            },
+                            gross: {
+                              amount: r.top_bid_currency_price ?? r.top_bid_price,
+                              nativeAmount: r.top_bid_price,
+                            },
+                          },
+                          topBidCurrency,
+                          query.displayCurrency
+                        )
+                      : null,
+                    source: getJoiSourceObject(topBidSource),
+                  }
                 : undefined,
               lastAppraisalValue: r.last_token_appraisal_value
                 ? formatEth(r.last_token_appraisal_value)
@@ -934,34 +951,34 @@ export const getUserTokensV9Options: RouteOptions = {
               attributes: query.includeAttributes
                 ? r.attributes
                   ? await Promise.all(
-                    _.map(r.attributes, async (attribute) => ({
-                      key: attribute.key,
-                      kind: attribute.kind,
-                      value: attribute.value,
-                      tokenCount: attribute.tokenCount,
-                      onSaleCount: attribute.onSaleCount,
-                      floorAskPrice: attribute.floorAskValue
-                        ? await getJoiPriceObject(
-                          {
-                            gross: {
-                              amount: String(
-                                attribute.floorAskCurrencyValue ?? attribute.floorAskValue
-                              ),
-                              nativeAmount: String(attribute.floorAskValue),
-                            },
-                          },
-                          attribute.floorAskCurrency
-                            ? _.replace(attribute.floorAskCurrency, "\\x", "0x")
-                            : Sdk.Common.Addresses.Native[config.chainId],
-                          query.displayCurrency
-                        )
-                        : null,
-                      topBidValue: attribute.topBidValue
-                        ? formatEth(attribute.topBidValue)
-                        : attribute.topBidValue,
-                      createdAt: new Date(attribute.createdAt).toISOString(),
-                    }))
-                  )
+                      _.map(r.attributes, async (attribute) => ({
+                        key: attribute.key,
+                        kind: attribute.kind,
+                        value: attribute.value,
+                        tokenCount: attribute.tokenCount,
+                        onSaleCount: attribute.onSaleCount,
+                        floorAskPrice: attribute.floorAskValue
+                          ? await getJoiPriceObject(
+                              {
+                                gross: {
+                                  amount: String(
+                                    attribute.floorAskCurrencyValue ?? attribute.floorAskValue
+                                  ),
+                                  nativeAmount: String(attribute.floorAskValue),
+                                },
+                              },
+                              attribute.floorAskCurrency
+                                ? _.replace(attribute.floorAskCurrency, "\\x", "0x")
+                                : Sdk.Common.Addresses.Native[config.chainId],
+                              query.displayCurrency
+                            )
+                          : null,
+                        topBidValue: attribute.topBidValue
+                          ? formatEth(attribute.topBidValue)
+                          : attribute.topBidValue,
+                        createdAt: new Date(attribute.createdAt).toISOString(),
+                      }))
+                    )
                   : []
                 : undefined,
             },
@@ -975,15 +992,15 @@ export const getUserTokensV9Options: RouteOptions = {
               id: r.floor_sell_id,
               price: r.floor_sell_id
                 ? await getJoiPriceObject(
-                  {
-                    gross: {
-                      amount: r.floor_sell_currency_value ?? r.floor_sell_value,
-                      nativeAmount: r.floor_sell_value,
+                    {
+                      gross: {
+                        amount: r.floor_sell_currency_value ?? r.floor_sell_value,
+                        nativeAmount: r.floor_sell_value,
+                      },
                     },
-                  },
-                  floorAskCurrency,
-                  query.displayCurrency
-                )
+                    floorAskCurrency,
+                    query.displayCurrency
+                  )
                 : null,
               maker: r.floor_sell_maker ? fromBuffer(r.floor_sell_maker) : null,
               kind: r.floor_sell_kind,
@@ -1010,7 +1027,7 @@ export const getUserTokensV9Options: RouteOptions = {
           tokens: await Promise.all(result),
           continuation,
         })
-        .header("cache-control", `max-age=${cacheControl}, must-revalidate, public`);
+        .header("cache-control", `${cacheControl}`);
     } catch (error) {
       logger.error(`get-user-tokens-${version}-handler`, `Handler failure: ${error}`);
       throw error;


### PR DESCRIPTION
## Description

This PR intends to quickly fix the cache-control directive in the indexer.
We are using 3 different ways of setting the cache that should be harmonized but outside of the scope of this PR.
There was 2 issues:
- the syntax was incorrect `cache-control: 1000`. Correct form is something like `cache-control: max-age=10, must-revalidate, public`
- In the other 2 ways of setting the cache, it uses the library hapi that expects the value to be passed in milliseconds but is converted in seconds under the hood. In this case, where we override the directly the `cache-control` header the value must be in seconds as defined by the [http standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control). This second issue might the main reason why the cache did not expired in Cloudfront. We were expecting 1 second while it was 1000 seconds (if it was not ignored completely because of the first issue).

## Checklist:

- [ x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules. -->

