### PR TITLE
fix(nftx-v3): buy orders should not be flagged as dynamic

### DIFF
--- a/packages/indexer/src/orderbook/orders/nftx-v3/index.ts
+++ b/packages/indexer/src/orderbook/orders/nftx-v3/index.ts
@@ -306,7 +306,7 @@ export const save = async (orderInfos: OrderInfo[]): Promise<SaveResult[]> => {
                 conduit: null,
                 fee_bps: 0,
                 fee_breakdown: undefined,
-                dynamic: true,
+                dynamic: false,
                 raw_data: sdkOrder.params,
                 expiration: validTo,
                 missing_royalties: missingRoyalties,
@@ -445,7 +445,9 @@ export const save = async (orderInfos: OrderInfo[]): Promise<SaveResult[]> => {
                 amount: index + 1,
                 nftxApiKey: config.nftxApiKey,
               });
-              tmpPriceList[index] = poolPrice;
+              if (poolPrice?.price?.gt(0)) {
+                tmpPriceList[index] = poolPrice;
+              }
             } catch {
               // Ignore errors
             }


### PR DESCRIPTION
Possibly the result of an early misunderstanding but buy orders don't need to be dynamic. Sell orders may be flagged as dynamic if they have premiums applied to them (as the price reduces significantly over time).

I also added an additional check to make sure the price-impact list doesn't include `0` price items (we were only excluding thrown errors as "no price")