### PR TITLE
Fix manifold mint function

### DIFF
--- a/packages/indexer/src/jobs/metadata-index/metadata-write-job.ts
+++ b/packages/indexer/src/jobs/metadata-index/metadata-write-job.ts
@@ -195,7 +195,7 @@ export default class MetadataIndexWriteJob extends AbstractRabbitMqJobHandler {
       {
         contract: toBuffer(contract),
         tokenId,
-        name: `${name}` || null,
+        name: _.isNull(name) ? null : `${name}`,
         description: description || null,
         image: imageUrl || null,
         tokenURI: tokenURI || null,

--- a/packages/indexer/src/orderbook/mints/calldata/detector/manifold.ts
+++ b/packages/indexer/src/orderbook/mints/calldata/detector/manifold.ts
@@ -258,8 +258,8 @@ export const extractByCollectionERC721 = async (
               tx: {
                 to: extension.toLowerCase(),
                 data: {
-                  // `mintBatch`
-                  signature: "0x26c858a4",
+                  // `mintProxy`
+                  signature: "0x07591acc",
                   params: [
                     {
                       kind: "contract",
@@ -324,8 +324,8 @@ export const extractByCollectionERC721 = async (
               tx: {
                 to: extension.toLowerCase(),
                 data: {
-                  // `mintBatch`
-                  signature: "0x26c858a4",
+                  // `mintProxy`
+                  signature: "0x07591acc",
                   params: [
                     {
                       kind: "contract",


### PR DESCRIPTION
Use mintProxy rather than mintBatch.

mintProxy is used for minting to other addresses.

mintBatch is used to mint to yourself (the mintFor param is used for delegation checking in that function, NOT for minting to another person)