### PR TITLE
feat: marketplace-config v2, return full currency token for bids

### DIFF
--- a/packages/indexer/src/api/endpoints/collections/get-collection-marketplace-configurations/v2.ts
+++ b/packages/indexer/src/api/endpoints/collections/get-collection-marketplace-configurations/v2.ts
@@ -1,0 +1,605 @@
+import * as Boom from "@hapi/boom";
+import { Request, RouteOptions } from "@hapi/hapi";
+import * as Sdk from "@reservoir0x/sdk";
+import Joi from "joi";
+
+import { redb } from "@/common/db";
+import { logger } from "@/common/logger";
+import { fromBuffer } from "@/common/utils";
+import { config } from "@/config/index";
+import { getNetworkSettings, getSubDomain } from "@/config/network";
+import { OrderKind } from "@/orderbook/orders";
+import { getOrUpdateBlurRoyalties } from "@/utils/blur";
+import { Currency, getCurrency } from "@/utils/currencies";
+import { checkMarketplaceIsFiltered } from "@/utils/marketplace-blacklists";
+import * as marketplaceFees from "@/utils/marketplace-fees";
+import * as paymentProcessor from "@/utils/payment-processor";
+import * as paymentProcessorV2 from "@/utils/payment-processor-v2";
+import * as registry from "@/utils/royalties/registry";
+
+type PaymentToken = {
+  address: string;
+  decimals?: number;
+  name?: string;
+  symbol?: string;
+};
+
+type Marketplace = {
+  name: string;
+  domain?: string;
+  imageUrl: string;
+  fee: {
+    bps: number;
+  };
+  royalties?: {
+    minBps: number;
+    maxBps: number;
+  };
+  orderbook: string | null;
+  exchanges: Record<
+    string,
+    {
+      enabled: boolean;
+      paymentTokens?: PaymentToken[];
+      traitBidSupported: boolean;
+      orderKind: OrderKind | null;
+      customFeesSupported: boolean;
+      numFeesSupported?: number;
+      collectionBidSupported?: boolean;
+      partialOrderSupported: boolean;
+      minimumBidExpiry?: number;
+      minimumPrecision?: string;
+      supportedBidCurrencies: PaymentToken[];
+      maxPriceRaw?: string;
+      minPriceRaw?: string;
+      oracleEnabled: boolean;
+    }
+  >;
+};
+
+const version = "v2";
+
+export const getCollectionMarketplaceConfigurationsV2Options: RouteOptions = {
+  cache: {
+    privacy: "public",
+    expiresIn: 60000,
+  },
+  description: "Marketplace configurations by collection",
+  notes: "This API returns recommended marketplace configurations given a collection id",
+  tags: ["api", "Collections"],
+  plugins: {
+    "hapi-swagger": {
+      order: 5,
+    },
+  },
+  validate: {
+    params: Joi.object({
+      collection: Joi.string()
+        .lowercase()
+        .required()
+        .description(
+          "Filter to a particular collection, e.g. `0x8d04a8c79ceb0889bdd12acdf3fa9d207ed3ff63`"
+        ),
+    }),
+    query: Joi.object({
+      tokenId: Joi.string()
+        .optional()
+        .description("When set, token-level royalties will be returned in the response"),
+    }),
+  },
+  response: {
+    schema: Joi.object({
+      marketplaces: Joi.array().items(
+        Joi.object({
+          name: Joi.string(),
+          domain: Joi.string().optional(),
+          imageUrl: Joi.string(),
+          fee: Joi.object({
+            bps: Joi.number(),
+          }).description("Marketplace Fee"),
+          royalties: Joi.object({
+            minBps: Joi.number(),
+            maxBps: Joi.number(),
+          }),
+          orderbook: Joi.string().allow(null),
+          exchanges: Joi.object()
+            .unknown()
+            .pattern(
+              Joi.string(),
+              Joi.object({
+                orderKind: Joi.string().allow(null),
+                enabled: Joi.boolean(),
+                customFeesSupported: Joi.boolean(),
+                numFeesSupported: Joi.number().optional(),
+                minimumBidExpiry: Joi.number(),
+                minimumPrecision: Joi.string(),
+                collectionBidSupported: Joi.boolean(),
+                traitBidSupported: Joi.boolean(),
+                partialOrderSupported: Joi.boolean().description(
+                  "This indicates whether or not multi quantity bidding is supported"
+                ),
+                supportedBidCurrencies: Joi.array()
+                  // .items(
+                  //   Joi.object({
+                  //     contract: Joi.string(),
+                  //     decimals: Joi.number().allow(null),
+                  //     name: Joi.string().allow(null),
+                  //     symbol: Joi.string().allow(null),
+                  //   })
+                  // )
+                  .items(Joi.any())
+                  .description("erc20 contract addresses"),
+                paymentTokens: Joi.array()
+                  .items(
+                    Joi.object({
+                      address: Joi.string(),
+                      decimals: Joi.number().allow(null),
+                      name: Joi.string().allow(null),
+                      symbol: Joi.string().allow(null),
+                    })
+                  )
+                  .allow(null),
+                maxPriceRaw: Joi.string().allow(null),
+                minPriceRaw: Joi.string().allow(null),
+                oracleEnabled: Joi.boolean(),
+              })
+            ),
+        })
+      ),
+    }),
+  },
+  handler: async (request: Request) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params = request.params as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const query = request.query as any;
+    const convertCurrencyToToken = ({ name, symbol, contract, decimals }: Currency) => ({
+      name,
+      symbol,
+      address: contract,
+      decimals,
+    });
+
+    try {
+      const collectionResult = await redb.oneOrNone(
+        `
+          SELECT
+            collections.royalties,
+            collections.new_royalties,
+            collections.marketplace_fees,
+            collections.payment_tokens,
+            collections.contract,
+            collections.token_count,
+            (
+              SELECT
+                kind
+              FROM contracts
+              WHERE contracts.address = collections.contract
+            ) AS contract_kind
+          FROM collections
+          JOIN contracts
+            ON collections.contract = contracts.address
+          WHERE collections.id = $/collection/
+          LIMIT 1
+        `,
+        { collection: params.collection }
+      );
+
+      if (!collectionResult) {
+        throw Boom.badRequest(`Collection ${params.collection} not found`);
+      }
+
+      let defaultRoyalties = collectionResult.royalties as Royalty[] | null;
+      if (query.tokenId) {
+        defaultRoyalties = await registry.getRegistryRoyalties(
+          fromBuffer(collectionResult.contract),
+          query.tokenId
+        );
+      }
+
+      const ns = getNetworkSettings();
+      const marketplaces: Marketplace[] = [];
+
+      await getCurrency(Sdk.Common.Addresses.WNative[config.chainId]);
+      const currencies = await Promise.all([
+        getCurrency(Sdk.Common.Addresses.WNative[config.chainId]),
+        ...Object.keys(ns.supportedBidCurrencies).map((contract) => getCurrency(contract)),
+      ]);
+      const currencyTokens = currencies.map((currency) => convertCurrencyToToken(currency));
+      const [wrappedNativeCurrency, ...supportedBidCurrencies] = currencyTokens;
+
+      if (Sdk.LooksRareV2.Addresses.Exchange[config.chainId]) {
+        marketplaces.push({
+          name: "LooksRare",
+          domain: "looksrare.org",
+          imageUrl: `https://${getSubDomain()}.reservoir.tools/redirect/sources/looksrare/logo/v2`,
+          fee: {
+            bps: 50,
+          },
+          orderbook: "looks-rare",
+          exchanges: {
+            "looks-rare-v2": {
+              enabled: false,
+              orderKind: "looks-rare-v2",
+              minimumBidExpiry: 15 * 60,
+              customFeesSupported: false,
+              supportedBidCurrencies: [wrappedNativeCurrency],
+              partialOrderSupported: false,
+              traitBidSupported: false,
+              oracleEnabled: false,
+            },
+            seaport: {
+              enabled: false,
+              orderKind: "seaport-v1.5",
+              minimumBidExpiry: 15 * 60,
+              customFeesSupported: false,
+              supportedBidCurrencies: [wrappedNativeCurrency],
+              partialOrderSupported: false,
+              traitBidSupported: false,
+              oracleEnabled: Boolean(
+                Sdk.SeaportBase.Addresses.ReservoirCancellationZone[config.chainId]
+              ),
+            },
+          },
+        });
+      }
+
+      if (Sdk.X2Y2.Addresses.Exchange[config.chainId]) {
+        marketplaces.push({
+          name: "X2Y2",
+          domain: "x2y2.io",
+          imageUrl: `https://${getSubDomain()}.reservoir.tools/redirect/sources/x2y2/logo/v2`,
+          fee: {
+            bps: 50,
+          },
+          orderbook: "x2y2",
+          exchanges: {
+            x2y2: {
+              orderKind: "x2y2",
+              enabled: false,
+              customFeesSupported: false,
+              supportedBidCurrencies: [wrappedNativeCurrency],
+              partialOrderSupported: false,
+              traitBidSupported: false,
+              oracleEnabled: false,
+            },
+          },
+        });
+      }
+
+      type Royalty = { bps: number; recipient: string };
+
+      // Handle Reservoir
+      {
+        const ppSupportedBidCurrencies =
+          config.chainId === 137 &&
+          params.collection === "0xa87dbcfa18adb7c00593e2c2469d83213c87aecd"
+            ? [
+                convertCurrencyToToken(
+                  await getCurrency("0x456f931298065b1852647de005dd27227146d8b9")
+                ),
+              ]
+            : supportedBidCurrencies;
+        marketplaces.push({
+          name: "Reservoir",
+          imageUrl: `https://${getSubDomain()}.reservoir.tools/redirect/sources/reservoir/logo/v2`,
+          fee: {
+            bps: 0,
+          },
+          royalties: defaultRoyalties
+            ? {
+                minBps: 0,
+                maxBps: defaultRoyalties.map((r) => r.bps).reduce((a, b) => a + b, 0),
+              }
+            : undefined,
+          orderbook: "reservoir",
+          exchanges: {
+            seaport: {
+              orderKind: "seaport-v1.5",
+              enabled: true,
+              customFeesSupported: true,
+              collectionBidSupported:
+                Number(collectionResult.token_count) <= config.maxTokenSetSize,
+              supportedBidCurrencies,
+              partialOrderSupported: true,
+              traitBidSupported: true,
+              oracleEnabled: Boolean(
+                Sdk.SeaportBase.Addresses.ReservoirCancellationZone[config.chainId]
+              ),
+            },
+            "payment-processor": {
+              orderKind: config.chainId === 11155111 ? "payment-processor-v2" : "payment-processor",
+              enabled: true,
+              customFeesSupported: true,
+              numFeesSupported: 1,
+              collectionBidSupported:
+                Number(collectionResult.token_count) <= config.maxTokenSetSize,
+              supportedBidCurrencies: ppSupportedBidCurrencies,
+              partialOrderSupported: false,
+              traitBidSupported: false,
+              oracleEnabled: false,
+            },
+            "payment-processor-v2": {
+              orderKind: "payment-processor-v2",
+              enabled: true,
+              customFeesSupported: true,
+              numFeesSupported: 1,
+              collectionBidSupported:
+                Number(collectionResult.token_count) <= config.maxTokenSetSize,
+              supportedBidCurrencies: ppSupportedBidCurrencies,
+              partialOrderSupported: collectionResult.contract_kind === "erc1155" ? true : false,
+              traitBidSupported: false,
+              oracleEnabled: true,
+            },
+          },
+        });
+      }
+
+      // Handle OpenSea
+      {
+        let openseaMarketplaceFees: Royalty[] = collectionResult.marketplace_fees?.opensea;
+        if (collectionResult.marketplace_fees?.opensea == null) {
+          openseaMarketplaceFees = marketplaceFees.getCollectionOpenseaFees();
+        }
+
+        const openseaRoyalties: Royalty[] = collectionResult.new_royalties?.opensea;
+
+        let maxOpenseaRoyaltiesBps: number | undefined;
+        if (openseaRoyalties) {
+          maxOpenseaRoyaltiesBps = openseaRoyalties
+            .map(({ bps }) => bps)
+            .reduce((a, b) => a + b, 0);
+        }
+
+        marketplaces.push({
+          name: "OpenSea",
+          domain: "opensea.io",
+          imageUrl: `https://${getSubDomain()}.reservoir.tools/redirect/sources/opensea/logo/v2`,
+          fee: {
+            bps: openseaMarketplaceFees[0]?.bps ?? 0,
+          },
+          royalties: maxOpenseaRoyaltiesBps
+            ? {
+                minBps: Math.min(
+                  maxOpenseaRoyaltiesBps,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  openseaRoyalties.some((r) => (r as any).required) ? maxOpenseaRoyaltiesBps : 50
+                ),
+                maxBps: maxOpenseaRoyaltiesBps,
+              }
+            : undefined,
+          orderbook: "opensea",
+          exchanges: {
+            seaport: {
+              orderKind: "seaport-v1.5",
+              enabled: false,
+              customFeesSupported: false,
+              minimumBidExpiry: 15 * 60,
+              supportedBidCurrencies,
+              paymentTokens: collectionResult.payment_tokens?.opensea,
+              partialOrderSupported: true,
+              traitBidSupported: true,
+              oracleEnabled: Boolean(
+                Sdk.SeaportBase.Addresses.ReservoirCancellationZone[config.chainId]
+              ),
+            },
+          },
+        });
+      }
+
+      // Handle Blur
+      if (Sdk.Blur.Addresses.Beth[config.chainId]) {
+        const royalties = await getOrUpdateBlurRoyalties(params.collection);
+        if (royalties) {
+          marketplaces.push({
+            name: "Blur",
+            domain: "blur.io",
+            imageUrl: `https://${getSubDomain()}.reservoir.tools/redirect/sources/blur.io/logo/v2`,
+            fee: {
+              bps: 0,
+            },
+            royalties: royalties
+              ? {
+                  minBps: royalties.minimumRoyaltyBps,
+                  // If the maximum royalty is not available for Blur, use the OpenSea one
+                  maxBps:
+                    royalties.maximumRoyaltyBps ??
+                    marketplaces[marketplaces.length - 1].royalties?.maxBps,
+                }
+              : undefined,
+            orderbook: "blur",
+            exchanges: {
+              blur: {
+                orderKind: "blur",
+                enabled: false,
+                customFeesSupported: false,
+                minimumPrecision: "0.01",
+                minimumBidExpiry: 10 * 24 * 60 * 60,
+                supportedBidCurrencies: [
+                  convertCurrencyToToken(
+                    await getCurrency(Sdk.Blur.Addresses.Beth[config.chainId])
+                  ),
+                ],
+                partialOrderSupported: true,
+                traitBidSupported: false,
+                oracleEnabled: false,
+              },
+            },
+          });
+        }
+      }
+
+      for await (const marketplace of marketplaces) {
+        let supportedOrderbooks = ["reservoir"];
+        switch (config.chainId) {
+          case 1: {
+            supportedOrderbooks = ["reservoir", "opensea", "looks-rare", "x2y2", "blur"];
+            break;
+          }
+          case 4: {
+            supportedOrderbooks = ["reservoir", "opensea", "looks-rare"];
+            break;
+          }
+          case 5: {
+            supportedOrderbooks = ["reservoir", "opensea", "looks-rare", "x2y2"];
+            break;
+          }
+          case 10:
+          case 56:
+          case 8453:
+          case 42161:
+          case 42170:
+          case 7777777:
+          case 11155111:
+          case 80001:
+          case 84531:
+          case 999:
+          case 137: {
+            supportedOrderbooks = ["reservoir", "opensea"];
+            break;
+          }
+        }
+
+        await Promise.allSettled(
+          Object.values(marketplace.exchanges).map(async (exchange) => {
+            exchange.enabled = !!(
+              marketplace.orderbook && supportedOrderbooks.includes(marketplace.orderbook)
+            );
+
+            if (exchange.enabled) {
+              let operators: string[] = [];
+
+              const seaportOperators = [Sdk.SeaportV15.Addresses.Exchange[config.chainId]];
+              if (Sdk.SeaportBase.Addresses.OpenseaConduitKey[config.chainId]) {
+                seaportOperators.push(
+                  new Sdk.SeaportBase.ConduitController(config.chainId).deriveConduit(
+                    Sdk.SeaportBase.Addresses.OpenseaConduitKey[config.chainId]
+                  )
+                );
+              }
+
+              switch (exchange.orderKind) {
+                case "blur": {
+                  operators = [
+                    Sdk.BlurV2.Addresses.Exchange[config.chainId],
+                    Sdk.BlurV2.Addresses.Delegate[config.chainId],
+                  ];
+                  break;
+                }
+
+                case "seaport-v1.5": {
+                  operators = seaportOperators;
+                  break;
+                }
+
+                case "x2y2": {
+                  operators = [
+                    Sdk.X2Y2.Addresses.Exchange[config.chainId],
+                    collectionResult.contract_kind === "erc1155"
+                      ? Sdk.X2Y2.Addresses.Erc1155Delegate[config.chainId]
+                      : Sdk.X2Y2.Addresses.Erc721Delegate[config.chainId],
+                  ];
+                  break;
+                }
+
+                case "looks-rare-v2": {
+                  operators = [
+                    Sdk.LooksRareV2.Addresses.Exchange[config.chainId],
+                    Sdk.LooksRareV2.Addresses.TransferManager[config.chainId],
+                  ];
+                  break;
+                }
+
+                case "payment-processor": {
+                  operators = [Sdk.PaymentProcessor.Addresses.Exchange[config.chainId]];
+                  break;
+                }
+
+                case "payment-processor-v2": {
+                  operators = [Sdk.PaymentProcessorV2.Addresses.Exchange[config.chainId]];
+                  break;
+                }
+              }
+
+              const exchangeBlocked = await checkMarketplaceIsFiltered(
+                params.collection,
+                operators
+              );
+
+              exchange.enabled = !exchangeBlocked;
+
+              if (exchange.enabled && exchange.orderKind === "payment-processor") {
+                const ppConfig = await paymentProcessor.getConfigByContract(params.collection);
+                if (ppConfig && ppConfig.securityPolicy.enforcePricingConstraints) {
+                  exchange.maxPriceRaw = ppConfig?.pricingBounds?.ceilingPrice;
+                  exchange.minPriceRaw = ppConfig?.pricingBounds?.floorPrice;
+                  if (ppConfig.paymentCoin) {
+                    const paymentToken = await getCurrency(ppConfig.paymentCoin);
+                    exchange.paymentTokens = [
+                      {
+                        address: ppConfig.paymentCoin,
+                        symbol: paymentToken.symbol,
+                        name: paymentToken.name,
+                        decimals: paymentToken.decimals,
+                      },
+                    ];
+                  }
+                }
+              } else if (exchange.enabled && exchange.orderKind === "payment-processor-v2") {
+                const settings = await paymentProcessorV2.getConfigByContract(params.collection);
+
+                let paymentTokens = [Sdk.Common.Addresses.Native[config.chainId]];
+                if (
+                  settings &&
+                  [
+                    paymentProcessorV2.PaymentSettings.DefaultPaymentMethodWhitelist,
+                    paymentProcessorV2.PaymentSettings.CustomPaymentMethodWhitelist,
+                  ].includes(settings.paymentSettings)
+                ) {
+                  paymentTokens = settings.whitelistedPaymentMethods;
+                } else if (
+                  settings?.paymentSettings ===
+                  paymentProcessorV2.PaymentSettings.PricingConstraints
+                ) {
+                  paymentTokens = [settings.constrainedPricingPaymentMethod];
+                  exchange.maxPriceRaw = settings?.pricingBounds?.ceilingPrice;
+                  exchange.minPriceRaw = settings?.pricingBounds?.floorPrice;
+                }
+
+                exchange.paymentTokens = await Promise.all(
+                  paymentTokens.map(async (token) => {
+                    const paymentToken = await getCurrency(token);
+                    return {
+                      address: token,
+                      symbol: paymentToken.symbol,
+                      name: paymentToken.name,
+                      decimals: paymentToken.decimals,
+                    };
+                  })
+                );
+                exchange.supportedBidCurrencies = exchange.paymentTokens.filter(
+                  (p) => p.address !== Sdk.Common.Addresses.Native[config.chainId]
+                );
+              }
+
+              exchange.supportedBidCurrencies.forEach(({ address, symbol, name, decimals }) => ({
+                address,
+                symbol,
+                name,
+                decimals,
+              }));
+            }
+          })
+        );
+      }
+
+      return { marketplaces };
+    } catch (error) {
+      logger.error(
+        `get-collection-marketplace-configurations-${version}-handler`,
+        `Handler failure: ${error}`
+      );
+      throw error;
+    }
+  },
+};

--- a/packages/indexer/src/api/endpoints/collections/index.ts
+++ b/packages/indexer/src/api/endpoints/collections/index.ts
@@ -31,5 +31,6 @@ export * from "@/api/endpoints/collections/post-spam-status-collection/v1";
 export * from "@/api/endpoints/collections/post-nsfw-status-collection/v1";
 export * from "@/api/endpoints/collections/post-collections-override/v1";
 export * from "@/api/endpoints/collections/get-collection-marketplace-configurations/v1";
+export * from "@/api/endpoints/collections/get-collection-marketplace-configurations/v2";
 export * from "@/api/endpoints/collections/get-collection-search/v1";
 export * from "@/api/endpoints/collections/get-top-traders/v1";

--- a/packages/indexer/src/api/routes.ts
+++ b/packages/indexer/src/api/routes.ts
@@ -648,6 +648,12 @@ export const setupRoutes = (server: Server) => {
   });
 
   server.route({
+    method: "GET",
+    path: "/collections/{collection}/marketplace-configurations/v2",
+    options: collectionsEndpoints.getCollectionMarketplaceConfigurationsV2Options,
+  });
+
+  server.route({
     method: "POST",
     path: "/collections/nsfw-status/v1",
     options: collectionsEndpoints.postNsfwStatusCollectionV1Options,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,27 +3212,7 @@
   dependencies:
     tslib "^2.3.1"
 
-"@openzeppelin/contracts@3.4.1-solc-0.7-2":
-  version "3.4.1-solc-0.7-2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
-  integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
-
-"@openzeppelin/contracts@3.4.2-solc-0.7":
-  version "3.4.2-solc-0.7"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz#38f4dbab672631034076ccdf2f3201fab1726635"
-  integrity sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==
-
-"@openzeppelin/contracts@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.0.tgz#3092d70ea60e3d1835466266b1d68ad47035a2d5"
-  integrity sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw==
-
-"@openzeppelin/contracts@4.8.3":
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.3.tgz#cbef3146bfc570849405f59cba18235da95a252a"
-  integrity sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==
-
-"@openzeppelin/contracts@^4.4.0":
+"@openzeppelin/contracts@3.4.1-solc-0.7-2", "@openzeppelin/contracts@3.4.2-solc-0.7", "@openzeppelin/contracts@4.7.0", "@openzeppelin/contracts@4.8.3", "@openzeppelin/contracts@^4.4.0", "@openzeppelin/contracts@^4.7.3":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.5.tgz#1eed23d4844c861a1835b5d33507c1017fa98de8"
   integrity sha512-ZK+W5mVhRppff9BE6YdR8CC52C8zAvsVAiWhEtQ5+oNxFE6h1WdeWo+FJSF8KKvtxxVYZ7MTP/5KoVpAU3aSWg==
@@ -3584,11 +3564,6 @@
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
-
-"@sindresorhus/is@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
-  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
@@ -3960,13 +3935,6 @@
   integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
-
-"@szmarczak/http-timer@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
-  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  dependencies:
-    defer-to-connect "^1.0.1"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -5254,29 +5222,12 @@ async-retry@^1.3.1:
   dependencies:
     retry "0.13.1"
 
-async@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
-  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
-  dependencies:
-    lodash "^4.17.11"
-
-async@^1.4.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
-
-async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.1:
+async@2.6.2, async@^1.4.2, async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.1, async@^2.6.4, async@^3.2.3:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
-
-async@^3.2.3:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
-  integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -6164,13 +6115,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
-
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -6536,19 +6480,6 @@ cacheable-lookup@^5.0.3:
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
   integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
-cacheable-request@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
-  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
-  dependencies:
-    clone-response "^1.0.2"
-    get-stream "^5.1.0"
-    http-cache-semantics "^4.0.0"
-    keyv "^3.0.0"
-    lowercase-keys "^2.0.0"
-    normalize-url "^4.1.0"
-    responselike "^1.0.2"
-
 cacheable-request@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.4.tgz#7a33ebf08613178b403635be7b899d3e69bbe817"
@@ -6597,12 +6528,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
-  integrity sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==
-
-camelcase@^5.0.0, camelcase@^5.3.1:
+camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -7658,7 +7584,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
@@ -7742,11 +7668,6 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
-
-defer-to-connect@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
-  integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
@@ -8062,11 +7983,6 @@ duplexer2@~0.1.0:
   dependencies:
     readable-stream "^2.0.2"
 
-duplexer3@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"
-  integrity sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==
-
 duplexer@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
@@ -8161,7 +8077,7 @@ encoding-down@5.0.4, encoding-down@~5.0.0:
     level-errors "^2.0.0"
     xtend "^4.0.1"
 
-encoding@^0.1.11, encoding@^0.1.13:
+encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -9430,14 +9346,7 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
-flat@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.1.tgz#a392059cc382881ff98642f5da4dde0a959f309b"
-  integrity sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==
-  dependencies:
-    is-buffer "~2.0.3"
-
-flat@^5.0.1, flat@^5.0.2:
+flat@^4.1.0, flat@^5.0.1, flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
@@ -9816,13 +9725,6 @@ get-port@^5.1.1:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
-get-stream@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
-  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
-
 get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
@@ -10042,24 +9944,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-got@9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
-  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
-  dependencies:
-    "@sindresorhus/is" "^0.14.0"
-    "@szmarczak/http-timer" "^1.1.2"
-    cacheable-request "^6.0.0"
-    decompress-response "^3.3.0"
-    duplexer3 "^0.1.4"
-    get-stream "^4.1.0"
-    lowercase-keys "^1.0.1"
-    mimic-response "^1.0.1"
-    p-cancelable "^1.0.0"
-    to-readable-stream "^1.0.0"
-    url-parse-lax "^3.0.0"
-
-got@^11.8.5:
+got@9.6.0, got@^11.8.5:
   version "11.8.6"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
   integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
@@ -10907,7 +10792,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.5, is-buffer@~2.0.3:
+is-buffer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -11143,11 +11028,6 @@ is-shared-array-buffer@^1.0.2:
   integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
   dependencies:
     call-bind "^1.0.2"
-
-is-stream@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -11808,11 +11688,6 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
-json-buffer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
-  integrity sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==
-
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -11908,12 +11783,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
-
-json5@^2.2.2, json5@^2.2.3:
+json5@^0.5.1, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -12001,13 +11871,6 @@ keccak@^3.0.0, keccak@^3.0.2:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
     readable-stream "^3.6.0"
-
-keyv@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
-  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
-  dependencies:
-    json-buffer "3.0.0"
 
 keyv@^4.0.0:
   version "4.5.3"
@@ -12436,7 +12299,7 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash.assign@^4.0.3, lodash.assign@^4.0.6:
+lodash.assign@^4.0.3:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
   integrity sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==
@@ -12561,12 +12424,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
+lodash@4.17.20, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -12626,11 +12484,6 @@ loupe@^2.3.1:
   integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
   dependencies:
     get-func-name "^2.0.0"
-
-lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lowercase-keys@^2.0.0:
   version "2.0.0"
@@ -12998,7 +12851,7 @@ mimic-fn@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
-mimic-response@^1.0.0, mimic-response@^1.0.1:
+mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
@@ -13030,47 +12883,12 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
-"minimatch@2 || 3", minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@5.0.1, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^7.4.3, minimatch@^9.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^5.0.1, minimatch@^5.1.0:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^7.4.3:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
-  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^9.0.1:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -13595,20 +13413,12 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@~1.7.1:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@~1.7.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-gyp-build-optional-packages@5.0.7:
   version "5.0.7"
@@ -13746,11 +13556,6 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
-
-normalize-url@^4.1.0:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
-  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
 normalize-url@^6.0.0, normalize-url@^6.0.1:
   version "6.1.0"
@@ -14221,11 +14026,6 @@ os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
-p-cancelable@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
-  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -14842,11 +14642,6 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
-prepend-http@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
-  integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
 prettier@^2.1.2, prettier@^2.5.1:
   version "2.8.8"
@@ -15710,13 +15505,6 @@ resolve@^1.10.0, resolve@^1.20.0, resolve@^1.8.1, resolve@~1.22.1:
     is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
-
-responselike@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
-  integrity sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==
-  dependencies:
-    lowercase-keys "^1.0.0"
 
 responselike@^2.0.0:
   version "2.0.1"
@@ -16937,10 +16725,10 @@ swagger-schema-official@2.0.0-bab6bed:
   resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz#70070468d6d2977ca5237b2e519ca7d06a2ea3fd"
   integrity sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==
 
-swagger-ui-dist@^3.47.1:
-  version "3.52.5"
-  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz#9aa8101a2be751f5145195b9e048bc21b12fac60"
-  integrity sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw==
+swagger-ui-dist@4.13, swagger-ui-dist@^3.47.1:
+  version "4.13.2"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-4.13.2.tgz#fb814efd51bf06aa8630c0a0af6e3caa48ac6552"
+  integrity sha512-jHL6UyIYpvEI7NsuWd0R3hJaPQTg6Oo4qSBo+oVfOEkv6rrQm/475RGSMmZgV6ajp+Sgrp9CqrDjQYAgQqiv1A==
 
 swagger2openapi@^7.0.8:
   version "7.0.8"
@@ -17258,11 +17046,6 @@ to-object-path@^0.3.0:
   integrity sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==
   dependencies:
     kind-of "^3.0.2"
-
-to-readable-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
-  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -17731,10 +17514,10 @@ undefsafe@^2.0.5:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-underscore@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+underscore@1.9.1, underscore@^1.12.1:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 undici-types@~5.26.4:
   version "5.26.5"
@@ -17850,13 +17633,6 @@ url-join@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
-
-url-parse-lax@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
-  integrity sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==
-  dependencies:
-    prepend-http "^2.0.0"
 
 url-parse@~1.5.10:
   version "1.5.10"
@@ -18000,10 +17776,10 @@ validate-npm-package-name@^4.0.0:
   dependencies:
     builtins "^5.0.0"
 
-validator@^10.0.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
-  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
+validator@^10.0.0, validator@^13.7.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
 
 varint@^5.0.0:
   version "5.0.2"
@@ -18660,36 +18436,10 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@13.1.2, yargs-parser@^13.1.2:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
-  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
-yargs-parser@21.1.1, yargs-parser@^21.0.0, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
+yargs-parser@13.1.2, yargs-parser@20.2.4, yargs-parser@21.1.1, yargs-parser@^13.1.2, yargs-parser@^2.4.1, yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^21.0.0, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs-parser@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
-  integrity sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==
-  dependencies:
-    camelcase "^3.0.0"
-    lodash.assign "^4.0.6"
-
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@1.6.0:
   version "1.6.0"


### PR DESCRIPTION
# Pull Request Template

## Description

New marketplace config v2 endpoint, only difference being that it returns an expanded list of currency objects for the `supportedBidCurrencies`, on the client we'll need this data in the case that ppv2 restricts bid currencies to the point where the client has to rely on data from this endpoint.

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
