### PR TITLE
Run db migration inside code

### DIFF
--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -9,9 +9,9 @@
     "compile": "tsc -b",
     "build": "yarn clean; yarn compile",
     "dev": "tsc-watch --onSuccess \"node -r module-alias/register ./dist/index.js\"",
-    "start": "yarn migrate up && node -r module-alias/register ./dist/index.js",
+    "start": "node -r module-alias/register ./dist/index.js",
     "migrate": "node ../../node_modules/node-pg-migrate/bin/node-pg-migrate -m ./src/migrations --no-check-order",
-    "debug": "yarn build && yarn migrate up && node --inspect -r module-alias/register ./dist/index.js",
+    "debug": "yarn build && node --inspect -r module-alias/register ./dist/index.js",
     "format": "prettier --write \"src/**/*.+(js|ts|json)\"",
     "cli": "node -r module-alias/register ./dist/cli/index.js",
     "test": "jest --no-watchman"

--- a/packages/indexer/src/common/db-migrate.ts
+++ b/packages/indexer/src/common/db-migrate.ts
@@ -16,7 +16,7 @@ export const runDBMigration = async () => {
       logger.info("postgresql-migration", `Start postgresql migration`);
       try {
         await migrationRunner({
-          dryRun: true,
+          dryRun: false,
           databaseUrl: {
             connectionString: config.databaseUrl
           },
@@ -47,13 +47,14 @@ export const runDBMigration = async () => {
       } finally {
         releaseLock(dbMigrationLock);
       }
+    } else {
+      logger.debug("postgresql-migration", `postgresql migration in progress in a different instance`);
+      await delay(CHECK_MIGRATION_INTERVAL);
     }
   }
 
   while(await redis.get(dbMigrationStatus) !== config.imageTag) {
     await doRun();
-    logger.debug("postgresql-migration", `postgresql migration in progress in a different instance`);
-    await delay(CHECK_MIGRATION_INTERVAL);
   }
   logger.info("postgresql-migration", `postgresql database schema is up to date`);
 }

--- a/packages/indexer/src/common/db-migrate.ts
+++ b/packages/indexer/src/common/db-migrate.ts
@@ -1,0 +1,60 @@
+import migrationRunner from "node-pg-migrate";
+import { acquireLock, redis, releaseLock } from "@/common/redis";
+import { logger } from "@/common/logger";
+import { delay } from "@/common/utils";
+
+import { config } from "@/config/index";
+
+export const runDBMigration = async () => {
+  const EXPIRATION_LOCK = 300
+  const CHECK_MIGRATION_INTERVAL = 1000
+  const dbMigrationLock = "db-migration-lock";
+  const dbMigrationStatus = "db-migration-status";
+
+  const doRun = async () => {
+    if (await acquireLock(dbMigrationLock, EXPIRATION_LOCK)) {
+      logger.info("postgresql-migration", `Start postgresql migration`);
+      try {
+        await migrationRunner({
+          dryRun: true,
+          databaseUrl: {
+            connectionString: config.databaseUrl
+          },
+          dir: './src/migrations',
+          ignorePattern: '\\..*',
+          schema: 'public',
+          createSchema: undefined,
+          migrationsSchema: undefined,
+          createMigrationsSchema: undefined,
+          migrationsTable: 'pgmigrations',
+          count: undefined,
+          timestamp: false,
+          file: undefined,
+          checkOrder: false,
+          verbose: true,
+          direction: 'up',
+          singleTransaction: true,
+          noLock: false,
+          fake: false,
+          decamelize: undefined
+        });
+
+        await redis.set(dbMigrationStatus, config.imageTag);
+
+        logger.info("postgresql-migration", `Stop postgresql migration`);
+      } catch(err) {
+        logger.error("postgresql-migration", `${err}`);
+      } finally {
+        releaseLock(dbMigrationLock);
+      }
+    }
+  }
+
+  while(await redis.get(dbMigrationStatus) !== config.imageTag) {
+    await doRun();
+    logger.debug("postgresql-migration", `postgresql migration in progress in a different instance`);
+    await delay(CHECK_MIGRATION_INTERVAL);
+  }
+  logger.info("postgresql-migration", `postgresql database schema is up to date`);
+  await delay(5000);
+}

--- a/packages/indexer/src/common/db-migrate.ts
+++ b/packages/indexer/src/common/db-migrate.ts
@@ -9,7 +9,7 @@ export const runDBMigration = async () => {
   const EXPIRATION_LOCK = 300
   const CHECK_MIGRATION_INTERVAL = 1000
   const dbMigrationLock = "db-migration-lock";
-  const dbMigrationStatus = "db-migration-status";
+  const dbMigrationVersion = "db-migration-version";
 
   const doRun = async () => {
     if (await acquireLock(dbMigrationLock, EXPIRATION_LOCK)) {
@@ -39,7 +39,7 @@ export const runDBMigration = async () => {
           decamelize: undefined
         });
 
-        await redis.set(dbMigrationStatus, config.imageTag);
+        await redis.set(dbMigrationVersion, config.imageTag);
 
         logger.info("postgresql-migration", `Stop postgresql migration`);
       } catch(err) {
@@ -53,7 +53,7 @@ export const runDBMigration = async () => {
     }
   }
 
-  while(await redis.get(dbMigrationStatus) !== config.imageTag) {
+  while(await redis.get(dbMigrationVersion) !== config.imageTag) {
     await doRun();
   }
   logger.info("postgresql-migration", `postgresql database schema is up to date`);

--- a/packages/indexer/src/common/db-migrate.ts
+++ b/packages/indexer/src/common/db-migrate.ts
@@ -56,5 +56,4 @@ export const runDBMigration = async () => {
     await delay(CHECK_MIGRATION_INTERVAL);
   }
   logger.info("postgresql-migration", `postgresql database schema is up to date`);
-  await delay(5000);
 }

--- a/packages/indexer/src/common/utils.ts
+++ b/packages/indexer/src/common/utils.ts
@@ -66,6 +66,10 @@ export const safeOracleTimestamp = async () => {
   return block.timestamp;
 };
 
+export const delay = async (ms: number) => {
+  return await new Promise(resolve => setTimeout(resolve, ms));
+}
+
 // --- Misc ---
 
 export const concat = <T>(...items: (T[] | undefined)[]) => {

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -12,17 +12,12 @@ import _ from "lodash";
 
 
 runDBMigration().then(() => {
-  console.log('2')
-
   if (Number(process.env.LOCAL_TESTING)) {
-    console.log('3')
     import("./setup");
   } else {
-    console.log('4')
     RabbitMq.createVhost()
       .then(() => RabbitMq.connect())
       .then(async () => {
-        console.log('5')
         // Sync the pods so rabbit queues assertion will run only once per deployment by a single pod
         if (await acquireLock(config.imageTag, 75)) {
           const hash = await RabbitMq.assertQueuesAndExchangesHash();
@@ -47,7 +42,6 @@ runDBMigration().then(() => {
           await redis.set(config.imageTag, "DONE", "EX", 60 * 60 * 24); // Update the lock ttl
           import("./setup");
         } else {
-          console.log('6')
           // Check every 1s if the rabbit queues assertion completed
           const intervalId = setInterval(async () => {
             if ((await redis.get(config.imageTag)) === "DONE") {

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -5,50 +5,60 @@ import "@/common/tracer";
 
 import { RabbitMq } from "@/common/rabbit-mq";
 import { acquireLock, redis } from "@/common/redis";
+import { runDBMigration } from "@/common/db-migrate";
 import { config } from "@/config/index";
 import { logger } from "@/common/logger";
 import _ from "lodash";
 
-if (Number(process.env.LOCAL_TESTING)) {
-  import("./setup");
-} else {
-  RabbitMq.createVhost()
-    .then(() => RabbitMq.connect())
-    .then(async () => {
-      // Sync the pods so rabbit queues assertion will run only once per deployment by a single pod
-      if (await acquireLock(config.imageTag, 75)) {
-        const hash = await RabbitMq.assertQueuesAndExchangesHash();
-        logger.info("rabbit-timing", `rabbit assertion hash ${hash}`);
-        if ((await redis.get(RabbitMq.hashKey)) !== hash) {
-          const start = _.now();
 
-          logger.info("rabbit-timing", `rabbit assertion starting in ${start}`);
-          await RabbitMq.assertQueuesAndExchanges();
-          logger.info("rabbit-timing", `rabbit assertion done in ${_.now() - start}ms`);
+runDBMigration().then(() => {
+  console.log('2')
 
-          // Clean any not in use queues
-          try {
-            await RabbitMq.deleteQueues(`${__dirname}/jobs`, true);
-          } catch (error) {
-            logger.error("rabbit-delete-queue", `Error deleting queue ${error}`);
+  if (Number(process.env.LOCAL_TESTING)) {
+    console.log('3')
+    import("./setup");
+  } else {
+    console.log('4')
+    RabbitMq.createVhost()
+      .then(() => RabbitMq.connect())
+      .then(async () => {
+        console.log('5')
+        // Sync the pods so rabbit queues assertion will run only once per deployment by a single pod
+        if (await acquireLock(config.imageTag, 75)) {
+          const hash = await RabbitMq.assertQueuesAndExchangesHash();
+          logger.info("rabbit-timing", `rabbit assertion hash ${hash}`);
+          if ((await redis.get(RabbitMq.hashKey)) !== hash) {
+            const start = _.now();
+
+            logger.info("rabbit-timing", `rabbit assertion starting in ${start}`);
+            await RabbitMq.assertQueuesAndExchanges();
+            logger.info("rabbit-timing", `rabbit assertion done in ${_.now() - start}ms`);
+
+            // Clean any not in use queues
+            try {
+              await RabbitMq.deleteQueues(`${__dirname}/jobs`, true);
+            } catch (error) {
+              logger.error("rabbit-delete-queue", `Error deleting queue ${error}`);
+            }
+
+            await redis.set(RabbitMq.hashKey, hash);
           }
 
-          await redis.set(RabbitMq.hashKey, hash);
+          await redis.set(config.imageTag, "DONE", "EX", 60 * 60 * 24); // Update the lock ttl
+          import("./setup");
+        } else {
+          console.log('6')
+          // Check every 1s if the rabbit queues assertion completed
+          const intervalId = setInterval(async () => {
+            if ((await redis.get(config.imageTag)) === "DONE") {
+              clearInterval(intervalId);
+              import("./setup");
+            }
+          }, 1000);
         }
-
-        await redis.set(config.imageTag, "DONE", "EX", 60 * 60 * 24); // Update the lock ttl
-        import("./setup");
-      } else {
-        // Check every 1s if the rabbit queues assertion completed
-        const intervalId = setInterval(async () => {
-          if ((await redis.get(config.imageTag)) === "DONE") {
-            clearInterval(intervalId);
-            import("./setup");
-          }
-        }, 1000);
-      }
-    })
-    .catch((error) => {
-      logger.error("rabbit-publisher-connect", `Error connecting to rabbit ${error}`);
-    });
-}
+      })
+      .catch((error) => {
+        logger.error("rabbit-publisher-connect", `Error connecting to rabbit ${error}`);
+      });
+  }
+});


### PR DESCRIPTION
# Run db migration in code

## Description

Kubernetes restart are caused by the db migration failing because they are running in parallel.

## Checklist:

- [x ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules. -->

