### PR TITLE
Improve openapi perf

### DIFF
--- a/packages/indexer/src/api/endpoints/admin/get-open-api.ts
+++ b/packages/indexer/src/api/endpoints/admin/get-open-api.ts
@@ -30,7 +30,7 @@ const getMethod = (object: { [key: string]: any }) => {
   }
 };
 
-let openapiData = {};
+let openapiData: object;
 
 export const generateOpenApiSpec = async () => {
   try {

--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -21,7 +21,6 @@ import { ApiKeyManager } from "@/models/api-keys";
 import { RateLimitRules } from "@/models/rate-limit-rules";
 import { BlockedKeyError, BlockedRouteError } from "@/models/rate-limit-rules/errors";
 import { countApiUsageJob } from "@/jobs/metrics/count-api-usage-job";
-import { generateOpenApiSpec } from "./endpoints/admin";
 import { RateLimitRuleEntity } from "@/models/rate-limit-rules/rate-limit-rule-entity";
 
 let server: Hapi.Server;
@@ -386,7 +385,6 @@ export const start = async (): Promise<void> => {
   setupRoutes(server);
 
   server.listener.keepAliveTimeout = 61000;
-  await generateOpenApiSpec();
   await server.start();
   logger.info("process", `Started on port ${config.port}`);
 };

--- a/packages/indexer/src/api/index.ts
+++ b/packages/indexer/src/api/index.ts
@@ -128,6 +128,8 @@ export const start = async (): Promise<void> => {
             "x-default": "demo-api-key",
           },
         },
+        documentationPage: config.environment !== "prod",
+        swaggerUI: config.environment !== "prod",
         schemes: ["https", "http"],
         host: `${getSubDomain()}.reservoir.tools`,
         cors: true,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR disable building openapi spec on startup of the application which can improve startup up to 5 seconds.
The openapi spec will still be build and cached upon first call to `/admin/open-api` endpoint.
This PR also disable swagger UI and documentation. 
This changes also have the benefit of reducing the memory usage for all instances of the indexer.