### PR TITLE
chore: remove lodash imports

### DIFF
--- a/packages/indexer/src/jobs/orderbook/opensea-bids-queue-job.ts
+++ b/packages/indexer/src/jobs/orderbook/opensea-bids-queue-job.ts
@@ -2,7 +2,6 @@ import { logger } from "@/common/logger";
 import { AbstractRabbitMqJobHandler } from "@/jobs/abstract-rabbit-mq-job-handler";
 import { GenericOrderInfo } from "@/jobs/orderbook/utils";
 import * as orders from "@/orderbook/orders";
-import _ from "lodash";
 
 export default class OpenseaBidsQueueJob extends AbstractRabbitMqJobHandler {
   queueName = "orderbook-opensea-bids-queue";
@@ -121,16 +120,14 @@ export default class OpenseaBidsQueueJob extends AbstractRabbitMqJobHandler {
       throw error;
     }
 
-    if (_.random(100) <= 75) {
-      logger.debug(
-        this.queueName,
-        JSON.stringify({
-          message: `[${kind}] Order save result: ${JSON.stringify(result)}`,
-          orderKind: kind,
-          resultStatus: result[0]?.status,
-        })
-      );
-    }
+    logger.debug(
+      this.queueName,
+      JSON.stringify({
+        message: `[${kind}] Order save result: ${JSON.stringify(result)}`,
+        orderKind: kind,
+        resultStatus: result[0]?.status,
+      })
+    );
   }
 
   public async addToQueue(orderInfos: GenericOrderInfo[]) {

--- a/packages/indexer/src/jobs/orderbook/utils.ts
+++ b/packages/indexer/src/jobs/orderbook/utils.ts
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import { logger } from "@/common/logger";
 import { AbstractRabbitMqJobHandler } from "@/jobs/abstract-rabbit-mq-job-handler";
 import * as orders from "@/orderbook/orders";
@@ -204,14 +202,12 @@ export const processOrder = async (job: AbstractRabbitMqJobHandler, payload: Gen
     throw error;
   }
 
-  if (_.random(100) <= 75) {
-    logger.debug(
-      job.queueName,
-      JSON.stringify({
-        message: `[${kind}] Order save result: ${JSON.stringify(result)}`,
-        orderKind: kind,
-        resultStatus: result[0]?.status,
-      })
-    );
-  }
+  logger.debug(
+    job.queueName,
+    JSON.stringify({
+      message: `[${kind}] Order save result: ${JSON.stringify(result)}`,
+      orderKind: kind,
+      resultStatus: result[0]?.status,
+    })
+  );
 };

--- a/packages/indexer/src/websockets/opensea/index.ts
+++ b/packages/indexer/src/websockets/opensea/index.ts
@@ -33,7 +33,6 @@ import { handleEvent as handleTraitOfferEvent } from "@/websockets/opensea/handl
 import { openseaBidsQueueJob } from "@/jobs/orderbook/opensea-bids-queue-job";
 import { openseaListingsJob } from "@/jobs/orderbook/opensea-listings-job";
 import { getNetworkSettings, getOpenseaNetworkName } from "@/config/network";
-import _ from "lodash";
 import { Collections } from "@/models/collections";
 import { metadataIndexFetchJob } from "@/jobs/metadata-index/metadata-fetch-job";
 
@@ -82,7 +81,7 @@ if (config.doWebsocketWork && config.openSeaApiKey) {
         const openSeaOrderParams = await handleEvent(eventType, event.payload);
 
         // Reduce amount of logs by only total the amount of events received from Ethereum mainnet.
-        if (_.random(100) <= 50 && (openSeaOrderParams || config.chainId === 1)) {
+        if (openSeaOrderParams || config.chainId === 1) {
           logger.debug(
             "opensea-websocket",
             JSON.stringify({


### PR DESCRIPTION
Hello there! We are working with a forked version of Reservoir. For some reason @nofir added a few randomness based conditions half a year ago that cause logs only to come through 75% of the time. That seems like a bad practice, because if you're actively using logs to debug certain situations you're not able to find them.

I strongly feel that these conditions shouldn't be there. It makes debugging things horribly ambiguous. If the Reservoir team feels strongly about keeping the randomness factor in, I would be happy to adjust it to make it configurable based on an environment variable. Let me know if that would be preferred here.
